### PR TITLE
fix: 修复加密备份上传后文件名丢失.enc 标识的问题

### DIFF
--- a/Monica for Android/app/src/main/java/takagi/ru/monica/utils/WebDavHelper.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/utils/WebDavHelper.kt
@@ -3525,10 +3525,16 @@ class WebDavHelper(
                 sardine!!.createDirectory(backupDir)
             }
             
-            // 生成带时间戳的文件名
+            // 生成带时间戳的文件名，保留加密标识
             val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
             val suffix = if (isPermanent) PERMANENT_SUFFIX else ""
-            val fileName = "monica_backup_$timestamp$suffix.zip"
+            // 根据源文件名判断是否加密，保留 .enc.zip 后缀
+            val isEncrypted = file.name.endsWith(".enc.zip")
+            val fileName = if (isEncrypted) {
+                "monica_backup_$timestamp$suffix.enc.zip"
+            } else {
+                "monica_backup_$timestamp$suffix.zip"
+            }
             val remotePath = "$backupDir/$fileName"
             
             // 使用流式上传避免内存溢出


### PR DESCRIPTION
问题：移动端生成备份文件时，加密文件带有.enc.zip后缀，但上传webdav时会用不带.enc的文件名覆盖上传。

修改：修改 WebDavHelper.kt 的 uploadBackup 方法，根据源文件名判断是否加密，保留.enc.zip 后缀。