### PR TITLE
Use native Argon2 for Bitwarden Argon2id KDF

### DIFF
--- a/Monica for Android/app/build.gradle
+++ b/Monica for Android/app/build.gradle
@@ -427,6 +427,12 @@ dependencies {
     
     // BouncyCastle for Argon2 (Bitwarden KDF support)
     implementation 'org.bouncycastle:bcprov-jdk18on:1.78.1'
+    // Native Argon2 backend for Bitwarden Argon2id KDF. This keeps high-memory
+    // KDF work off the Android JVM heap.
+    implementation('com.lambdapioneer.argon2kt:argon2kt:1.6.0') {
+        exclude group: 'androidx.appcompat', module: 'appcompat'
+        exclude group: 'androidx.core', module: 'core-ktx'
+    }
 
     // Brand icon loading now uses remote PNG assets from Stratum Auth app
     

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/bitwarden/crypto/BitwardenCrypto.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/bitwarden/crypto/BitwardenCrypto.kt
@@ -1,6 +1,9 @@
 package takagi.ru.monica.bitwarden.crypto
 
 import android.util.Base64
+import com.lambdapioneer.argon2kt.Argon2Kt
+import com.lambdapioneer.argon2kt.Argon2Mode
+import com.lambdapioneer.argon2kt.Argon2Version
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
@@ -36,6 +39,7 @@ import javax.crypto.spec.SecretKeySpec
 object BitwardenCrypto {
     private const val MAX_CIPHER_STRING_LENGTH = 1024 * 1024
     private const val MAX_BASE64_PART_LENGTH = 1024 * 1024
+    private const val ARGON2_JVM_FALLBACK_MAX_MEMORY_MB = 64
     
     // 加密类型常量
     const val CIPHER_TYPE_AES_CBC = 0
@@ -46,6 +50,7 @@ object BitwardenCrypto {
     private const val MAC_KEY_SIZE = 32   // 256 bits
     private const val IV_SIZE = 16        // 128 bits
     private const val SEND_KEY_MATERIAL_SIZE = 16
+    private val nativeArgon2 by lazy { Argon2Kt() }
     
     /**
      * 对称加密密钥 - 包含加密密钥和 MAC 密钥
@@ -139,20 +144,95 @@ object BitwardenCrypto {
         memory: Int = 64,
         parallelism: Int = 4
     ): ByteArray {
-        // 使用 BouncyCastle 的 Argon2 实现
         val passwordBytes = password.toByteArray(StandardCharsets.UTF_8)
         // 注意: salt 应该已经被调用者小写化，这里不再重复处理
         val saltBytes = salt.toByteArray(StandardCharsets.UTF_8)
         
         // keyguard: val saltHash = hashSha256(salt)
         val saltHash = MessageDigest.getInstance("SHA-256").digest(saltBytes)
-        
+
+        return try {
+            deriveMasterKeyArgon2Native(
+                passwordBytes = passwordBytes,
+                saltHash = saltHash,
+                iterations = iterations,
+                memory = memory,
+                parallelism = parallelism
+            )
+        } catch (nativeError: Throwable) {
+            if (memory > ARGON2_JVM_FALLBACK_MAX_MEMORY_MB) {
+                throw IllegalStateException(
+                    "Bitwarden Argon2id KDF requires ${memory}MB memory; native Argon2 failed " +
+                        "and JVM fallback is disabled to avoid Android heap OOM.",
+                    nativeError
+                )
+            }
+
+            deriveMasterKeyArgon2BouncyCastle(
+                passwordBytes = passwordBytes,
+                saltHash = saltHash,
+                iterations = iterations,
+                memory = memory,
+                parallelism = parallelism
+            )
+        } finally {
+            passwordBytes.fill(0)
+            saltBytes.fill(0)
+            saltHash.fill(0)
+        }
+    }
+
+    private fun deriveMasterKeyArgon2Native(
+        passwordBytes: ByteArray,
+        saltHash: ByteArray,
+        iterations: Int,
+        memory: Int,
+        parallelism: Int
+    ): ByteArray {
+        val passwordBuffer = ByteBuffer.allocateDirect(passwordBytes.size).apply {
+            put(passwordBytes)
+            flip()
+        }
+        val saltBuffer = ByteBuffer.allocateDirect(saltHash.size).apply {
+            put(saltHash)
+            flip()
+        }
+
+        return try {
+            val result = nativeArgon2.hash(
+                mode = Argon2Mode.ARGON2_ID,
+                password = passwordBuffer,
+                salt = saltBuffer,
+                tCostInIterations = iterations,
+                mCostInKibibyte = argon2MemoryKiB(memory),
+                parallelism = parallelism,
+                hashLengthInBytes = 32,
+                version = Argon2Version.V13
+            )
+            val hash = result.rawHashAsByteArray()
+            wipeDirectBuffer(result.rawHash)
+            wipeDirectBuffer(result.encodedOutput)
+            hash
+        } finally {
+            wipeDirectBuffer(passwordBuffer)
+            wipeDirectBuffer(saltBuffer)
+        }
+    }
+
+    private fun deriveMasterKeyArgon2BouncyCastle(
+        passwordBytes: ByteArray,
+        saltHash: ByteArray,
+        iterations: Int,
+        memory: Int,
+        parallelism: Int
+    ): ByteArray {
+        // 使用 BouncyCastle 的 Argon2 实现作为低内存兼容回退。
         val params = org.bouncycastle.crypto.params.Argon2Parameters.Builder(
             org.bouncycastle.crypto.params.Argon2Parameters.ARGON2_id
         )
             .withSalt(saltHash)  // 使用 SHA256 哈希后的 salt
             .withIterations(iterations)
-            .withMemoryAsKB(memory * 1024)
+            .withMemoryAsKB(argon2MemoryKiB(memory))
             .withParallelism(parallelism)
             .withVersion(org.bouncycastle.crypto.params.Argon2Parameters.ARGON2_VERSION_13)
             .build()
@@ -164,6 +244,23 @@ object BitwardenCrypto {
         generator.generateBytes(passwordBytes, hash)
         
         return hash
+    }
+
+    private fun wipeDirectBuffer(buffer: ByteBuffer) {
+        val duplicate = buffer.duplicate()
+        duplicate.clear()
+        while (duplicate.hasRemaining()) {
+            duplicate.put(0.toByte())
+        }
+    }
+
+    private fun argon2MemoryKiB(memoryMb: Int): Int {
+        require(memoryMb > 0) { "Bitwarden Argon2id KDF memory must be positive: $memoryMb" }
+        return try {
+            Math.multiplyExact(memoryMb, 1024)
+        } catch (e: ArithmeticException) {
+            throw IllegalArgumentException("Bitwarden Argon2id KDF memory is too large: ${memoryMb}MB", e)
+        }
     }
     
     /**

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/bitwarden/repository/BitwardenRepository.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/bitwarden/repository/BitwardenRepository.kt
@@ -121,6 +121,12 @@ class BitwardenRepository(private val context: Context) {
                 // 其他 400 错误
                 rawError.contains("400") && rawError.contains("invalid_grant") ->
                     "认证失败：可能是服务器区域或自建地址不匹配、SSO 账户限制、或验证流程未完成，请重试"
+
+                // 高内存 Argon2id KDF 在当前设备/ABI/native 库不可用时的明确提示
+                rawError.contains("Bitwarden Argon2id KDF requires", ignoreCase = true) ||
+                rawError.contains("ARGON2_MEMORY_ALLOCATION_ERROR", ignoreCase = true) ||
+                rawError.contains("ARGON2JNI_MALLOC_FAILED", ignoreCase = true) ->
+                    "登录失败：当前设备无法完成该 Bitwarden Argon2id KDF 参数。请降低服务端 KDF 内存参数后重试，或使用支持该参数的官方客户端。"
                 
                 // 默认返回原始错误（截断过长内容）
                 else -> {


### PR DESCRIPTION
## Summary

Fixes an `OutOfMemoryError` when Monica connects to a self-hosted Bitwarden/Vaultwarden account using Argon2id with high KDF memory settings.

## Problem

Monica currently derives Bitwarden Argon2id master keys with BouncyCastle's JVM Argon2 implementation. When the server returns a high KDF memory value, for example:

- KDF: Argon2id
- Memory: 512 MB
- Iterations: 10
- Parallelism: 8

the Argon2 working memory is allocated on the Android JVM/ART heap. This can crash the app with `OutOfMemoryError`, even when `android:largeHeap="true"` is enabled.

## Changes

- Add `com.lambdapioneer.argon2kt:argon2kt` as a native Argon2 backend.
- Use native Argon2 for Bitwarden Argon2id master key derivation.
- Keep the existing BouncyCastle implementation as a fallback only for low-memory KDF settings.
- Disable JVM fallback for high-memory Argon2id settings to avoid Android heap OOM.
- Add a clearer user-facing error message if native Argon2 cannot complete the KDF.

## Scope

This is limited to Bitwarden KDF handling.

Unchanged:

- PBKDF2 KDF
- vault encryption/decryption logic
- KeePass support
- WebDAV support
- local storage

## Validation

- `./gradlew :app:compileDebugKotlin`
- `./gradlew :app:assembleRelease`
- Tested with self-hosted Bitwarden/Vaultwarden using Argon2id memory `512 MB`, iterations `10`, parallelism `8`.