### PR TITLE
fix(autofill): 修复 WebView 登录页无法填充 + 新增主动式无障碍提示

### DIFF
--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/ActiveFillNotificationHelper.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/ActiveFillNotificationHelper.kt
@@ -1,0 +1,92 @@
+package takagi.ru.monica.autofill_ng
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import takagi.ru.monica.R
+import takagi.ru.monica.autofill_ng.AutofillPickerActivityV2
+
+/**
+ * 主动填充通知（阶段1）：AccessibilityService 检测到某 App 有匹配密码条目时，
+ * 主动发一条通知；点击通知唤起 Monica 手动选择器（与快捷磁贴入口等价）。
+ */
+object ActiveFillNotificationHelper {
+
+    private const val CHANNEL_ID = "active_fill_channel"
+    private const val CHANNEL_NAME = "主动填充提示"
+    private const val NOTIFICATION_ID = 9528
+
+    fun createChannel(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                description = "检测到可填充的登录框时提示"
+            }
+            context.getSystemService(NotificationManager::class.java)
+                ?.createNotificationChannel(channel)
+        }
+    }
+
+    private fun canPost(context: Context): Boolean {
+        val manager = NotificationManagerCompat.from(context)
+        if (!manager.areNotificationsEnabled()) return false
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = context.getSystemService(NotificationManager::class.java)
+                ?.getNotificationChannel(CHANNEL_ID)
+            if (channel != null && channel.importance == NotificationManager.IMPORTANCE_NONE) {
+                return false
+            }
+        }
+        return true
+    }
+
+    fun showActiveFillNotification(context: Context, packageName: String, appName: String): Boolean {
+        createChannel(context)
+        if (!canPost(context)) {
+            android.util.Log.w("ActiveFill", "Notifications unavailable, skip active fill prompt")
+            return false
+        }
+
+        val intent = Intent(context, AutofillPickerActivityV2::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            putExtra(AutofillPickerActivityV2.EXTRA_MANUAL_MODE, true)
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            NOTIFICATION_ID,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_key)
+            .setContentTitle("Monica 可填充")
+            .setContentText("点此为 $appName 填充账号密码")
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .setAutoCancel(true)
+            .setContentIntent(pendingIntent)
+            .setTimeoutAfter(15_000)
+            .build()
+
+        return try {
+            NotificationManagerCompat.from(context).notify(NOTIFICATION_ID, notification)
+            true
+        } catch (e: SecurityException) {
+            android.util.Log.w("ActiveFill", "Notification permission not granted", e)
+            false
+        }
+    }
+
+    fun dismissNotification(context: Context) {
+        NotificationManagerCompat.from(context).cancel(NOTIFICATION_ID)
+    }
+}

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/ActiveFillNotificationHelper.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/ActiveFillNotificationHelper.kt
@@ -1,34 +1,34 @@
 package takagi.ru.monica.autofill_ng
 
+import android.Manifest
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
 import takagi.ru.monica.R
-import takagi.ru.monica.autofill_ng.AutofillPickerActivityV2
 
 /**
- * 主动填充通知（阶段1）：AccessibilityService 检测到某 App 有匹配密码条目时，
- * 主动发一条通知；点击通知唤起 Monica 手动选择器（与快捷磁贴入口等价）。
+ * AccessibilityService 检测到当前应用已绑定密码条目时显示主动填充通知。
  */
 object ActiveFillNotificationHelper {
 
     private const val CHANNEL_ID = "active_fill_channel"
-    private const val CHANNEL_NAME = "主动填充提示"
     private const val NOTIFICATION_ID = 9528
 
     fun createChannel(context: Context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(
                 CHANNEL_ID,
-                CHANNEL_NAME,
+                context.getString(R.string.autofill_active_fill_channel_name),
                 NotificationManager.IMPORTANCE_HIGH
             ).apply {
-                description = "检测到可填充的登录框时提示"
+                description = context.getString(R.string.autofill_active_fill_channel_desc)
             }
             context.getSystemService(NotificationManager::class.java)
                 ?.createNotificationChannel(channel)
@@ -36,6 +36,13 @@ object ActiveFillNotificationHelper {
     }
 
     private fun canPost(context: Context): Boolean {
+        if (
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) !=
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            return false
+        }
         val manager = NotificationManagerCompat.from(context)
         if (!manager.areNotificationsEnabled()) return false
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -58,6 +65,7 @@ object ActiveFillNotificationHelper {
         val intent = Intent(context, AutofillPickerActivityV2::class.java).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
             putExtra(AutofillPickerActivityV2.EXTRA_MANUAL_MODE, true)
+            putExtra(AutofillPickerActivityV2.EXTRA_MANUAL_TARGET_PACKAGE, packageName)
         }
         val pendingIntent = PendingIntent.getActivity(
             context,
@@ -68,10 +76,13 @@ object ActiveFillNotificationHelper {
 
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_key)
-            .setContentTitle("Monica 可填充")
-            .setContentText("点此为 $appName 填充账号密码")
+            .setContentTitle(context.getString(R.string.autofill_active_fill_notification_content_title))
+            .setContentText(
+                context.getString(R.string.autofill_active_fill_notification_content_text, appName)
+            )
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
             .setAutoCancel(true)
             .setContentIntent(pendingIntent)
             .setTimeoutAfter(15_000)

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/ActiveFillPromptThrottle.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/ActiveFillPromptThrottle.kt
@@ -1,0 +1,36 @@
+package takagi.ru.monica.autofill_ng
+
+internal class ActiveFillPromptThrottle(
+    private val throttleMs: Long,
+) {
+    private val nextAllowedAtByPackage = mutableMapOf<String, Long>()
+
+    @Synchronized
+    fun tryAcquire(packageName: String, nowMs: Long): Boolean {
+        val key = packageName.trim().lowercase()
+        if (key.isEmpty()) return false
+
+        val nextAllowedAt = nextAllowedAtByPackage[key] ?: Long.MIN_VALUE
+        if (nowMs < nextAllowedAt) return false
+
+        nextAllowedAtByPackage[key] = nowMs + throttleMs.coerceAtLeast(0L)
+        if (nextAllowedAtByPackage.size > MAX_TRACKED_PACKAGES) {
+            nextAllowedAtByPackage.entries.removeAll { (_, allowedAt) -> allowedAt <= nowMs }
+            while (nextAllowedAtByPackage.size > MAX_TRACKED_PACKAGES) {
+                val oldestKey = nextAllowedAtByPackage.minByOrNull { (_, allowedAt) -> allowedAt }?.key
+                    ?: break
+                nextAllowedAtByPackage.remove(oldestKey)
+            }
+        }
+        return true
+    }
+
+    @Synchronized
+    fun clear() {
+        nextAllowedAtByPackage.clear()
+    }
+
+    private companion object {
+        const val MAX_TRACKED_PACKAGES = 64
+    }
+}

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/AutofillPickerActivityV2.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/AutofillPickerActivityV2.kt
@@ -154,6 +154,7 @@ class AutofillPickerActivityV2 : BaseMonicaActivity() {
     companion object {
         private const val EXTRA_ARGS = "extra_args"
         const val EXTRA_MANUAL_MODE = "extra_manual_mode"
+        const val EXTRA_MANUAL_TARGET_PACKAGE = "extra_manual_target_package"
         const val EXTRA_IME_MODE = "extra_ime_mode"
         private const val DUPLICATE_LAUNCH_WINDOW_MS = 1500L
         private const val MANUAL_ACCESSIBILITY_FILL_DELAY_MS = 450L
@@ -292,12 +293,19 @@ class AutofillPickerActivityV2 : BaseMonicaActivity() {
         intent.getBooleanExtra(EXTRA_MANUAL_MODE, false)
     }
 
+    private val manualTargetPackage by lazy {
+        intent.getStringExtra(EXTRA_MANUAL_TARGET_PACKAGE)
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+    }
+
     private val imeMode by lazy {
         intent.getBooleanExtra(EXTRA_IME_MODE, false)
     }
 
     private val manualModeReason by lazy {
         when {
+            manualTargetPackage != null -> "active_fill_notification"
             explicitManualMode -> "explicit_manual_extra"
             !args.fieldSignatureKey.isNullOrBlank() -> "framework_context_field_signature"
             !args.applicationId.isNullOrBlank() -> "framework_context_application_id"
@@ -965,6 +973,7 @@ class AutofillPickerActivityV2 : BaseMonicaActivity() {
         username: String,
         password: String,
         preferPasswordField: Boolean = false,
+        expectedTargetPackage: String? = manualTargetPackage,
     ): Boolean {
         if (!MonicaAccessibilityService.isCredentialFillAvailable(applicationContext)) {
             AutofillLogger.i("PICKER", "Manual accessibility fill unavailable; service is not active")
@@ -977,6 +986,7 @@ class AutofillPickerActivityV2 : BaseMonicaActivity() {
             requestManualAccessibilityFillWithRetry(
                 appContext = appContext,
                 packageNameToSkip = packageNameToSkip,
+                expectedTargetPackage = expectedTargetPackage,
                 username = username,
                 password = password,
                 preferPasswordField = preferPasswordField,
@@ -993,19 +1003,23 @@ class AutofillPickerActivityV2 : BaseMonicaActivity() {
     private fun requestManualAccessibilityFillWithRetry(
         appContext: Context,
         packageNameToSkip: String,
+        expectedTargetPackage: String?,
         username: String,
         password: String,
         preferPasswordField: Boolean,
         attempt: Int,
     ) {
         val activePackage = MonicaAccessibilityService.getActiveWindowPackageName().orEmpty()
-        val shouldWaitForTargetWindow = activePackage.isBlank() ||
-            activePackage.equals(packageNameToSkip, ignoreCase = true)
-        val filled = if (shouldWaitForTargetWindow) {
+        val resolvedTargetPackage = resolveManualFillTargetPackage(
+            activePackage = activePackage,
+            packageNameToSkip = packageNameToSkip,
+            expectedTargetPackage = expectedTargetPackage,
+        )
+        val filled = if (resolvedTargetPackage == null) {
             false
         } else {
             MonicaAccessibilityService.requestCredentialFill(
-                targetPackageName = activePackage,
+                targetPackageName = resolvedTargetPackage,
                 username = username,
                 password = password,
                 preferPasswordField = preferPasswordField
@@ -1014,12 +1028,18 @@ class AutofillPickerActivityV2 : BaseMonicaActivity() {
 
         AutofillLogger.i(
             "PICKER",
-            "Manual accessibility fill attempt: attempt=$attempt, filled=$filled, activePackage=${activePackage.ifBlank { "none" }}"
+            "Manual accessibility fill attempt: attempt=$attempt, filled=$filled, activePackage=${activePackage.ifBlank { "none" }}, expectedPackage=${expectedTargetPackage.orEmpty().ifBlank { "any" }}"
         )
 
         if (filled || attempt >= MANUAL_ACCESSIBILITY_MAX_ATTEMPTS) {
             if (!filled) {
-                if (preferPasswordField && username.isBlank()) {
+                if (!expectedTargetPackage.isNullOrBlank()) {
+                    android.widget.Toast.makeText(
+                        appContext,
+                        R.string.autofill_active_fill_target_unavailable,
+                        android.widget.Toast.LENGTH_SHORT,
+                    ).show()
+                } else if (preferPasswordField && username.isBlank()) {
                     ClipboardUtils.copyToClipboard(
                         context = appContext,
                         text = password,
@@ -1044,6 +1064,7 @@ class AutofillPickerActivityV2 : BaseMonicaActivity() {
             requestManualAccessibilityFillWithRetry(
                 appContext = appContext,
                 packageNameToSkip = packageNameToSkip,
+                expectedTargetPackage = expectedTargetPackage,
                 username = username,
                 password = password,
                 preferPasswordField = preferPasswordField,

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/AutofillPreferences.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/AutofillPreferences.kt
@@ -39,6 +39,8 @@ class AutofillPreferences(private val context: Context) {
         
         // 配置键
         private val KEY_AUTOFILL_ENABLED = booleanPreferencesKey("autofill_enabled")
+        private val KEY_ACTIVE_FILL_NOTIFICATION_ENABLED =
+            booleanPreferencesKey("active_fill_notification_enabled")
         private val KEY_DOMAIN_MATCH_STRATEGY = stringPreferencesKey("domain_match_strategy")
         private val KEY_FILL_SUGGESTIONS_ENABLED = booleanPreferencesKey("fill_suggestions_enabled")
         private val KEY_MANUAL_SELECTION_ENABLED = booleanPreferencesKey("manual_selection_enabled")
@@ -120,6 +122,16 @@ class AutofillPreferences(private val context: Context) {
     suspend fun setAutofillEnabled(enabled: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[KEY_AUTOFILL_ENABLED] = enabled
+        }
+    }
+
+    val isActiveFillNotificationEnabled: Flow<Boolean> = context.dataStore.data.map { preferences ->
+        preferences[KEY_ACTIVE_FILL_NOTIFICATION_ENABLED] ?: false
+    }
+
+    suspend fun setActiveFillNotificationEnabled(enabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[KEY_ACTIVE_FILL_NOTIFICATION_ENABLED] = enabled
         }
     }
     

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/ManualFillTargetPolicy.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/ManualFillTargetPolicy.kt
@@ -1,0 +1,18 @@
+package takagi.ru.monica.autofill_ng
+
+internal fun resolveManualFillTargetPackage(
+    activePackage: String,
+    packageNameToSkip: String,
+    expectedTargetPackage: String?,
+): String? {
+    val active = activePackage.trim()
+    if (active.isEmpty() || active.equals(packageNameToSkip.trim(), ignoreCase = true)) {
+        return null
+    }
+
+    val expected = expectedTargetPackage?.trim()?.takeIf { it.isNotEmpty() }
+    if (expected != null && !active.equals(expected, ignoreCase = true)) {
+        return null
+    }
+    return expected ?: active
+}

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/service/MonicaAccessibilityService.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/service/MonicaAccessibilityService.kt
@@ -590,14 +590,33 @@ class MonicaAccessibilityService : AccessibilityService() {
 
     private fun setNodeText(node: AccessibilityNodeInfo?, text: String): Boolean {
         if (node == null || text.isBlank()) return false
+        if (!node.isFocused) {
+            node.performAction(AccessibilityNodeInfo.ACTION_FOCUS)
+        }
+        node.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+
+        // WebView (H5 / X5·TBS 等内核) 的 HTML <input> 对 ACTION_SET_TEXT
+        // 常表现为"接受命令但不刷新界面"——它只改无障碍节点的 text 属性，
+        // 不触发 JS input 事件，框架(React/Vue)因此读不到新值、界面仍空白。
+        // 优先用 ACTION_PASTE：粘贴会触发 input 事件，HTML 框架才能捕获并刷新 UI。
+        // 副作用：临时覆盖系统剪贴板（主流密码管理器的通用做法）。
+        runCatching {
+            val clipboard =
+                getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+            clipboard.setPrimaryClip(
+                android.content.ClipData.newPlainText("monica_fill", text)
+            )
+        }
+        val pasted = runCatching {
+            node.performAction(AccessibilityNodeInfo.ACTION_PASTE)
+        }.getOrDefault(false)
+        if (pasted) return true
+
+        // 原生 EditText 等不支持 paste 的场景，回退 SET_TEXT（原生控件能正确刷新）。
         val args = Bundle().apply {
             putCharSequence(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, text)
         }
         return runCatching {
-            if (!node.isFocused) {
-                node.performAction(AccessibilityNodeInfo.ACTION_FOCUS)
-            }
-            node.performAction(AccessibilityNodeInfo.ACTION_CLICK)
             node.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, args)
         }.getOrDefault(false)
     }

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/service/MonicaAccessibilityService.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/service/MonicaAccessibilityService.kt
@@ -11,11 +11,20 @@ import android.text.InputType
 import android.view.accessibility.AccessibilityManager
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.first
+import takagi.ru.monica.data.PasswordDatabase
+import takagi.ru.monica.repository.PasswordRepository
+import takagi.ru.monica.autofill_ng.ActiveFillNotificationHelper
 
 class MonicaAccessibilityService : AccessibilityService() {
     private var lastPackageName: String = ""
     private var lastUrl: String = ""
     private var lastScanTime = 0L
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private lateinit var passwordRepository: PasswordRepository
+    private var lastActiveFillPackage: String = ""
+    private var lastActiveFillTime = 0L
 
     companion object {
         private const val TAG = "MonicaAccessibility"
@@ -28,6 +37,7 @@ class MonicaAccessibilityService : AccessibilityService() {
         private const val SCORE_FOCUSED_BONUS = 12
         private const val SCORE_PASSWORD_FLAG = 90
         private const val SCORE_CONFIRM_PENALTY = 35
+        private const val ACTIVE_FILL_THROTTLE_MS = 5000L
 
         @Volatile
         private var activeInstance: MonicaAccessibilityService? = null
@@ -139,6 +149,12 @@ class MonicaAccessibilityService : AccessibilityService() {
     override fun onServiceConnected() {
         super.onServiceConnected()
         activeInstance = this
+        runCatching {
+            passwordRepository = PasswordRepository(PasswordDatabase.getDatabase(this).passwordEntryDao())
+            ActiveFillNotificationHelper.createChannel(this)
+        }.onFailure { e ->
+            Log.w(TAG, "Failed to init active fill repository", e)
+        }
     }
 
     override fun onAccessibilityEvent(event: AccessibilityEvent?) {
@@ -147,22 +163,29 @@ class MonicaAccessibilityService : AccessibilityService() {
             if (event.eventType !in trackedEventTypes) return
 
             val packageName = event.packageName?.toString().orEmpty()
-            val browserSpec = browserSpecsByPackage[packageName] ?: return
+            val browserSpec = browserSpecsByPackage[packageName]
+            if (browserSpec != null) {
+                val now = System.currentTimeMillis()
+                if (packageName == lastPackageName && now - lastScanTime < SCAN_THROTTLE_MS) return
+                lastScanTime = now
 
-            val now = System.currentTimeMillis()
-            if (packageName == lastPackageName && now - lastScanTime < SCAN_THROTTLE_MS) return
-            lastScanTime = now
+                val root = rootInActiveWindow ?: event.source ?: return
+                val url = findBrowserUrl(root, browserSpec) ?: return
 
-            val root = rootInActiveWindow ?: event.source ?: return
-            val url = findBrowserUrl(root, browserSpec) ?: return
+                if (packageName == lastPackageName && url == lastUrl) return
 
-            if (packageName == lastPackageName && url == lastUrl) return
+                lastPackageName = packageName
+                lastUrl = url
+                BrowserAutofillContextStore.update(packageName, url)
+                ValidatorContextManager.updateContext(packageName, url)
+                Log.d(TAG, "Updated browser context: pkg=$packageName, hasUrl=${url.isNotBlank()}")
+                return
+            }
 
-            lastPackageName = packageName
-            lastUrl = url
-            BrowserAutofillContextStore.update(packageName, url)
-            ValidatorContextManager.updateContext(packageName, url)
-            Log.d(TAG, "Updated browser context: pkg=$packageName, hasUrl=${url.isNotBlank()}")
+            // 阶段1：非浏览器 App 的登录字段聚焦 -> 主动发填充通知
+            if (event.eventType == AccessibilityEvent.TYPE_VIEW_FOCUSED) {
+                maybePromptActiveFill(packageName, event.source)
+            }
         }.onFailure { e ->
             Log.w(TAG, "onAccessibilityEvent failed", e)
         }
@@ -176,6 +199,7 @@ class MonicaAccessibilityService : AccessibilityService() {
         if (activeInstance === this) {
             activeInstance = null
         }
+        serviceScope.cancel()
         super.onDestroy()
     }
 
@@ -253,6 +277,77 @@ class MonicaAccessibilityService : AccessibilityService() {
     }.onFailure { e ->
         Log.w(TAG, "fillCredentialsInActiveWindow failed", e)
     }.getOrDefault(false)
+
+    private fun maybePromptActiveFill(packageName: String, source: AccessibilityNodeInfo?) {
+        if (packageName.isBlank() || source == null) return
+        if (!isLikelyLoginField(source)) return
+
+        val now = System.currentTimeMillis()
+        if (packageName == lastActiveFillPackage && now - lastActiveFillTime < ACTIVE_FILL_THROTTLE_MS) return
+
+        serviceScope.launch {
+            try {
+                val entries = passwordRepository.getAllPasswordEntries().first()
+                val match = entries.firstOrNull { entry ->
+                    entry.appPackageName
+                        .split("[,;| ]".toRegex())
+                        .any { it.equals(packageName, ignoreCase = true) }
+                }
+                if (match != null) {
+                    lastActiveFillPackage = packageName
+                    lastActiveFillTime = now
+                    val shown = ActiveFillNotificationHelper.showActiveFillNotification(
+                        this@MonicaAccessibilityService,
+                        packageName,
+                        match.appName.ifBlank { packageName }
+                    )
+                    Log.d(TAG, "Active fill prompt for pkg=$packageName shown=$shown")
+                } else {
+                    Log.d(TAG, "No matching credential for pkg=$packageName, skip active fill")
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "Active fill query failed", e)
+            }
+        }
+    }
+
+    private fun isLikelyLoginField(node: AccessibilityNodeInfo): Boolean {
+        if (node.isPassword) return true
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            val inputType = node.inputType
+            val inputClass = inputType and InputType.TYPE_MASK_CLASS
+            val variation = inputType and InputType.TYPE_MASK_VARIATION
+            if (
+                (inputClass == InputType.TYPE_CLASS_TEXT && (
+                    variation == InputType.TYPE_TEXT_VARIATION_PASSWORD ||
+                        variation == InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD ||
+                        variation == InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD ||
+                        variation == InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS ||
+                        variation == InputType.TYPE_TEXT_VARIATION_PERSON_NAME ||
+                        variation == InputType.TYPE_TEXT_VARIATION_WEB_EMAIL_ADDRESS
+                    )) ||
+                (inputClass == InputType.TYPE_CLASS_NUMBER &&
+                    variation == InputType.TYPE_NUMBER_VARIATION_PASSWORD)
+            ) {
+                return true
+            }
+        }
+        if (node.isEditable) {
+            val signals = buildList {
+                add(node.hintText?.toString().orEmpty())
+                add(node.contentDescription?.toString().orEmpty())
+                add(node.viewIdResourceName.orEmpty())
+            }.joinToString(" ").lowercase()
+            if (
+                signals.contains("password") || signals.contains("passwd") || signals.contains("pwd") ||
+                signals.contains("username") || signals.contains("user_name") ||
+                signals.contains("email") || signals.contains("login") || signals.contains("account")
+            ) {
+                return true
+            }
+        }
+        return false
+    }
 
     private fun findBrowserUrl(root: AccessibilityNodeInfo, browserSpec: BrowserSpec): String? {
         val queue = ArrayDeque<Pair<AccessibilityNodeInfo, Int>>()

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/service/MonicaAccessibilityService.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/service/MonicaAccessibilityService.kt
@@ -2,29 +2,68 @@ package takagi.ru.monica.service
 
 import android.accessibilityservice.AccessibilityServiceInfo
 import android.accessibilityservice.AccessibilityService
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import android.graphics.Rect
 import android.os.Build
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.os.PersistableBundle
 import android.util.Log
 import android.text.InputType
 import android.view.accessibility.AccessibilityManager
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
 import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
+import takagi.ru.monica.autofill_ng.ActiveFillPromptThrottle
+import takagi.ru.monica.autofill_ng.AutofillPreferences
 import takagi.ru.monica.data.PasswordDatabase
+import takagi.ru.monica.data.isLinkedToApp
+import takagi.ru.monica.data.linkedAppBindings
 import takagi.ru.monica.repository.PasswordRepository
 import takagi.ru.monica.autofill_ng.ActiveFillNotificationHelper
+
+internal data class TemporaryClipboardSnapshot(
+    val text: String?,
+    val label: String?,
+    val canVerify: Boolean,
+)
+
+internal fun shouldRestoreTemporaryClipboard(
+    snapshot: TemporaryClipboardSnapshot,
+    expectedLabel: String,
+    expectedText: String,
+): Boolean {
+    return !snapshot.canVerify ||
+        (snapshot.label == expectedLabel && snapshot.text == expectedText)
+}
 
 class MonicaAccessibilityService : AccessibilityService() {
     private var lastPackageName: String = ""
     private var lastUrl: String = ""
     private var lastScanTime = 0L
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private lateinit var passwordRepository: PasswordRepository
-    private var lastActiveFillPackage: String = ""
-    private var lastActiveFillTime = 0L
+    private val passwordRepository by lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
+        PasswordRepository(PasswordDatabase.getDatabase(applicationContext).passwordEntryDao())
+    }
+    private val autofillPreferences by lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
+        AutofillPreferences(applicationContext)
+    }
+    private val activeFillPromptThrottle = ActiveFillPromptThrottle(ACTIVE_FILL_THROTTLE_MS)
+    @Volatile
+    private var activeFillNotificationEnabled = false
+    private val clipboardHandler = Handler(Looper.getMainLooper())
+    private val temporaryClipboardLock = Any()
+    private var temporaryClipboardRestoreRunnable: Runnable? = null
+    private var temporaryClipboardGeneration = 0L
+    private var temporaryClipboardOriginal: ClipData? = null
+    private var temporaryClipboardOriginalWasReadable = false
+    private var temporaryClipboardActive = false
+    private var temporaryClipboardExpectedText: String? = null
 
     companion object {
         private const val TAG = "MonicaAccessibility"
@@ -38,6 +77,8 @@ class MonicaAccessibilityService : AccessibilityService() {
         private const val SCORE_PASSWORD_FLAG = 90
         private const val SCORE_CONFIRM_PENALTY = 35
         private const val ACTIVE_FILL_THROTTLE_MS = 5000L
+        private const val TEMPORARY_CLIPBOARD_LABEL = "Monica autofill"
+        private const val TEMPORARY_CLIPBOARD_RESTORE_DELAY_MS = 500L
 
         @Volatile
         private var activeInstance: MonicaAccessibilityService? = null
@@ -146,14 +187,25 @@ class MonicaAccessibilityService : AccessibilityService() {
         val left: Int
     )
 
+    private data class TemporaryClipboardToken(
+        val generation: Long,
+        val label: String,
+        val text: String,
+    )
+
     override fun onServiceConnected() {
         super.onServiceConnected()
         activeInstance = this
-        runCatching {
-            passwordRepository = PasswordRepository(PasswordDatabase.getDatabase(this).passwordEntryDao())
-            ActiveFillNotificationHelper.createChannel(this)
-        }.onFailure { e ->
-            Log.w(TAG, "Failed to init active fill repository", e)
+        serviceScope.launch {
+            autofillPreferences.isActiveFillNotificationEnabled.collectLatest { enabled ->
+                activeFillNotificationEnabled = enabled
+                if (enabled) {
+                    ActiveFillNotificationHelper.createChannel(this@MonicaAccessibilityService)
+                } else {
+                    activeFillPromptThrottle.clear()
+                    ActiveFillNotificationHelper.dismissNotification(this@MonicaAccessibilityService)
+                }
+            }
         }
     }
 
@@ -199,6 +251,8 @@ class MonicaAccessibilityService : AccessibilityService() {
         if (activeInstance === this) {
             activeInstance = null
         }
+        ActiveFillNotificationHelper.dismissNotification(this)
+        restoreTemporaryClipboardImmediately()
         serviceScope.cancel()
         super.onDestroy()
     }
@@ -213,7 +267,6 @@ class MonicaAccessibilityService : AccessibilityService() {
         val activePackageName = root.packageName?.toString().orEmpty()
         if (
             !targetPackageName.isNullOrBlank() &&
-            activePackageName.isNotBlank() &&
             !activePackageName.equals(targetPackageName, ignoreCase = true)
         ) {
             Log.d(TAG, "Skip accessibility fill: active package mismatch ($activePackageName != $targetPackageName)")
@@ -279,27 +332,28 @@ class MonicaAccessibilityService : AccessibilityService() {
     }.getOrDefault(false)
 
     private fun maybePromptActiveFill(packageName: String, source: AccessibilityNodeInfo?) {
+        if (!activeFillNotificationEnabled) return
         if (packageName.isBlank() || source == null) return
         if (!isLikelyLoginField(source)) return
 
         val now = System.currentTimeMillis()
-        if (packageName == lastActiveFillPackage && now - lastActiveFillTime < ACTIVE_FILL_THROTTLE_MS) return
+        if (!activeFillPromptThrottle.tryAcquire(packageName, now)) return
 
         serviceScope.launch {
             try {
                 val entries = passwordRepository.getAllPasswordEntries().first()
-                val match = entries.firstOrNull { entry ->
-                    entry.appPackageName
-                        .split("[,;| ]".toRegex())
-                        .any { it.equals(packageName, ignoreCase = true) }
-                }
-                if (match != null) {
-                    lastActiveFillPackage = packageName
-                    lastActiveFillTime = now
+                val match = entries.firstOrNull { entry -> entry.isLinkedToApp(packageName) }
+                if (match != null && activeFillNotificationEnabled) {
+                    val linkedAppName = match.linkedAppBindings()
+                        .firstOrNull { binding ->
+                            binding.packageName.equals(packageName, ignoreCase = true)
+                        }
+                        ?.appName
+                        .orEmpty()
                     val shown = ActiveFillNotificationHelper.showActiveFillNotification(
                         this@MonicaAccessibilityService,
                         packageName,
-                        match.appName.ifBlank { packageName }
+                        linkedAppName.ifBlank { packageName }
                     )
                     Log.d(TAG, "Active fill prompt for pkg=$packageName shown=$shown")
                 } else {
@@ -313,24 +367,22 @@ class MonicaAccessibilityService : AccessibilityService() {
 
     private fun isLikelyLoginField(node: AccessibilityNodeInfo): Boolean {
         if (node.isPassword) return true
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            val inputType = node.inputType
-            val inputClass = inputType and InputType.TYPE_MASK_CLASS
-            val variation = inputType and InputType.TYPE_MASK_VARIATION
-            if (
-                (inputClass == InputType.TYPE_CLASS_TEXT && (
-                    variation == InputType.TYPE_TEXT_VARIATION_PASSWORD ||
-                        variation == InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD ||
-                        variation == InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD ||
-                        variation == InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS ||
-                        variation == InputType.TYPE_TEXT_VARIATION_PERSON_NAME ||
-                        variation == InputType.TYPE_TEXT_VARIATION_WEB_EMAIL_ADDRESS
-                    )) ||
-                (inputClass == InputType.TYPE_CLASS_NUMBER &&
-                    variation == InputType.TYPE_NUMBER_VARIATION_PASSWORD)
-            ) {
-                return true
-            }
+        val inputType = node.inputType
+        val inputClass = inputType and InputType.TYPE_MASK_CLASS
+        val variation = inputType and InputType.TYPE_MASK_VARIATION
+        if (
+            (inputClass == InputType.TYPE_CLASS_TEXT && (
+                variation == InputType.TYPE_TEXT_VARIATION_PASSWORD ||
+                    variation == InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD ||
+                    variation == InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD ||
+                    variation == InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS ||
+                    variation == InputType.TYPE_TEXT_VARIATION_PERSON_NAME ||
+                    variation == InputType.TYPE_TEXT_VARIATION_WEB_EMAIL_ADDRESS
+                )) ||
+            (inputClass == InputType.TYPE_CLASS_NUMBER &&
+                variation == InputType.TYPE_NUMBER_VARIATION_PASSWORD)
+        ) {
+            return true
         }
         if (node.isEditable) {
             val signals = buildList {
@@ -461,31 +513,29 @@ class MonicaAccessibilityService : AccessibilityService() {
         if (node.isPassword) {
             passwordScore += SCORE_PASSWORD_FLAG
         }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            val inputType = node.inputType
-            val inputClass = inputType and InputType.TYPE_MASK_CLASS
-            val variation = inputType and InputType.TYPE_MASK_VARIATION
-            if (
-                (inputClass == InputType.TYPE_CLASS_TEXT && (
-                    variation == InputType.TYPE_TEXT_VARIATION_PASSWORD ||
-                        variation == InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD ||
-                        variation == InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD
-                    )) ||
-                (inputClass == InputType.TYPE_CLASS_NUMBER &&
-                    variation == InputType.TYPE_NUMBER_VARIATION_PASSWORD)
-            ) {
-                passwordScore += SCORE_PASSWORD_FLAG
-            }
-            if (
-                inputClass == InputType.TYPE_CLASS_TEXT &&
-                (
-                    variation == InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS ||
-                        variation == InputType.TYPE_TEXT_VARIATION_PERSON_NAME ||
-                        variation == InputType.TYPE_TEXT_VARIATION_WEB_EMAIL_ADDRESS
-                    )
-            ) {
-                usernameScore += SCORE_USERNAME_SIGNAL
-            }
+        val inputType = node.inputType
+        val inputClass = inputType and InputType.TYPE_MASK_CLASS
+        val variation = inputType and InputType.TYPE_MASK_VARIATION
+        if (
+            (inputClass == InputType.TYPE_CLASS_TEXT && (
+                variation == InputType.TYPE_TEXT_VARIATION_PASSWORD ||
+                    variation == InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD ||
+                    variation == InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD
+                )) ||
+            (inputClass == InputType.TYPE_CLASS_NUMBER &&
+                variation == InputType.TYPE_NUMBER_VARIATION_PASSWORD)
+        ) {
+            passwordScore += SCORE_PASSWORD_FLAG
+        }
+        if (
+            inputClass == InputType.TYPE_CLASS_TEXT &&
+            (
+                variation == InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS ||
+                    variation == InputType.TYPE_TEXT_VARIATION_PERSON_NAME ||
+                    variation == InputType.TYPE_TEXT_VARIATION_WEB_EMAIL_ADDRESS
+                )
+        ) {
+            usernameScore += SCORE_USERNAME_SIGNAL
         }
 
         if (signals.contains("password") || signals.contains("passwd") || signals.contains("pwd")) {
@@ -595,29 +645,161 @@ class MonicaAccessibilityService : AccessibilityService() {
         }
         node.performAction(AccessibilityNodeInfo.ACTION_CLICK)
 
-        // WebView (H5 / X5·TBS 等内核) 的 HTML <input> 对 ACTION_SET_TEXT
-        // 常表现为"接受命令但不刷新界面"——它只改无障碍节点的 text 属性，
-        // 不触发 JS input 事件，框架(React/Vue)因此读不到新值、界面仍空白。
-        // 优先用 ACTION_PASTE：粘贴会触发 input 事件，HTML 框架才能捕获并刷新 UI。
-        // 副作用：临时覆盖系统剪贴板（主流密码管理器的通用做法）。
-        runCatching {
-            val clipboard =
-                getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
-            clipboard.setPrimaryClip(
-                android.content.ClipData.newPlainText("monica_fill", text)
-            )
+        val existingText = runCatching { node.text?.toString().orEmpty() }.getOrDefault("")
+        val canPasteWithoutAppending = if (existingText.isEmpty()) {
+            true
+        } else {
+            val selectionArgs = Bundle().apply {
+                putInt(AccessibilityNodeInfo.ACTION_ARGUMENT_SELECTION_START_INT, 0)
+                putInt(AccessibilityNodeInfo.ACTION_ARGUMENT_SELECTION_END_INT, existingText.length)
+            }
+            runCatching {
+                node.performAction(AccessibilityNodeInfo.ACTION_SET_SELECTION, selectionArgs)
+            }.getOrDefault(false)
         }
-        val pasted = runCatching {
-            node.performAction(AccessibilityNodeInfo.ACTION_PASTE)
-        }.getOrDefault(false)
-        if (pasted) return true
 
-        // 原生 EditText 等不支持 paste 的场景，回退 SET_TEXT（原生控件能正确刷新）。
+        if (canPasteWithoutAppending) {
+            val temporaryClipboard = setTemporaryClipboard(text)
+            if (temporaryClipboard != null) {
+                val pasted = runCatching {
+                    node.performAction(AccessibilityNodeInfo.ACTION_PASTE)
+                }.getOrDefault(false)
+                scheduleTemporaryClipboardRestore(temporaryClipboard)
+                if (pasted) return true
+            }
+        }
+
         val args = Bundle().apply {
             putCharSequence(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, text)
         }
         return runCatching {
             node.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, args)
         }.getOrDefault(false)
+    }
+
+    private fun setTemporaryClipboard(text: String): TemporaryClipboardToken? {
+        val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+            ?: return null
+
+        synchronized(temporaryClipboardLock) {
+            val startedSession = !temporaryClipboardActive
+            if (startedSession) {
+                val originalResult = runCatching { clipboard.primaryClip }
+                temporaryClipboardOriginal = originalResult.getOrNull()
+                temporaryClipboardOriginalWasReadable = originalResult.isSuccess
+                temporaryClipboardActive = true
+            }
+
+            val generation = temporaryClipboardGeneration + 1L
+            val temporaryClip = ClipData.newPlainText(TEMPORARY_CLIPBOARD_LABEL, text).apply {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    description.extras = PersistableBundle().apply {
+                        putBoolean("android.content.extra.IS_SENSITIVE", true)
+                    }
+                }
+            }
+            val written = runCatching { clipboard.setPrimaryClip(temporaryClip) }.isSuccess
+            if (!written) {
+                if (startedSession) {
+                    resetTemporaryClipboardSessionLocked()
+                }
+                return null
+            }
+
+            temporaryClipboardGeneration = generation
+            temporaryClipboardExpectedText = text
+            return TemporaryClipboardToken(
+                generation = generation,
+                label = TEMPORARY_CLIPBOARD_LABEL,
+                text = text,
+            )
+        }
+    }
+
+    private fun scheduleTemporaryClipboardRestore(token: TemporaryClipboardToken) {
+        val restoreRunnable = Runnable { restoreTemporaryClipboardIfOwned(token) }
+        synchronized(temporaryClipboardLock) {
+            if (!temporaryClipboardActive || token.generation != temporaryClipboardGeneration) return
+            temporaryClipboardRestoreRunnable?.let(clipboardHandler::removeCallbacks)
+            temporaryClipboardRestoreRunnable = restoreRunnable
+            clipboardHandler.postDelayed(
+                restoreRunnable,
+                TEMPORARY_CLIPBOARD_RESTORE_DELAY_MS,
+            )
+        }
+    }
+
+    private fun restoreTemporaryClipboardImmediately() {
+        val token = synchronized(temporaryClipboardLock) {
+            if (!temporaryClipboardActive) return
+            TemporaryClipboardToken(
+                generation = temporaryClipboardGeneration,
+                label = TEMPORARY_CLIPBOARD_LABEL,
+                text = temporaryClipboardExpectedText.orEmpty(),
+            )
+        }
+        restoreTemporaryClipboardIfOwned(token)
+    }
+
+    private fun restoreTemporaryClipboardIfOwned(token: TemporaryClipboardToken) {
+        val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+        synchronized(temporaryClipboardLock) {
+            if (!temporaryClipboardActive || token.generation != temporaryClipboardGeneration) return
+
+            val snapshot = if (clipboard == null) {
+                TemporaryClipboardSnapshot(text = null, label = null, canVerify = false)
+            } else {
+                runCatching {
+                    val currentClip = clipboard.primaryClip
+                    TemporaryClipboardSnapshot(
+                        text = currentClip
+                            ?.takeIf { it.itemCount > 0 }
+                            ?.getItemAt(0)
+                            ?.coerceToText(this)
+                            ?.toString(),
+                        label = currentClip?.description?.label?.toString(),
+                        canVerify = true,
+                    )
+                }.getOrElse {
+                    TemporaryClipboardSnapshot(text = null, label = null, canVerify = false)
+                }
+            }
+
+            if (
+                clipboard != null &&
+                shouldRestoreTemporaryClipboard(snapshot, token.label, token.text)
+            ) {
+                val restored = if (
+                    temporaryClipboardOriginalWasReadable &&
+                    temporaryClipboardOriginal != null
+                ) {
+                    runCatching {
+                        clipboard.setPrimaryClip(requireNotNull(temporaryClipboardOriginal))
+                    }.isSuccess
+                } else {
+                    false
+                }
+                if (!restored) {
+                    runCatching {
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                            clipboard.clearPrimaryClip()
+                        } else {
+                            clipboard.setPrimaryClip(ClipData.newPlainText("", ""))
+                        }
+                    }
+                }
+            }
+
+            resetTemporaryClipboardSessionLocked()
+        }
+    }
+
+    private fun resetTemporaryClipboardSessionLocked() {
+        temporaryClipboardRestoreRunnable?.let(clipboardHandler::removeCallbacks)
+        temporaryClipboardRestoreRunnable = null
+        temporaryClipboardOriginal = null
+        temporaryClipboardOriginalWasReadable = false
+        temporaryClipboardActive = false
+        temporaryClipboardExpectedText = null
     }
 }

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/ui/screens/AutofillSettingsV2Screen.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/ui/screens/AutofillSettingsV2Screen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material.icons.outlined.Key
 import androidx.compose.material.icons.outlined.Language
 import androidx.compose.material.icons.outlined.Link
 import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.Smartphone
@@ -115,6 +116,7 @@ fun AutofillSettingsV2Screen(
     }
 
     val autofillEnabled by preferences.isAutofillEnabled.collectAsState(initial = true)
+    val activeFillNotificationEnabled by preferences.isActiveFillNotificationEnabled.collectAsState(initial = false)
     val appSettings by settingsManager.settingsFlow.collectAsState(initial = AppSettings())
     val autofillAuthRequired = appSettings.autofillAuthRequired
     val strictMode by preferences.isBitwardenStrictModeEnabled.collectAsState(initial = true)
@@ -513,6 +515,16 @@ fun AutofillSettingsV2Screen(
                     checked = autofillEnabled,
                     onCheckedChange = { enabled ->
                         scope.launch { preferences.setAutofillEnabled(enabled) }
+                    },
+                )
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                SwitchSettingItem(
+                    icon = Icons.Outlined.Notifications,
+                    title = stringResource(R.string.autofill_active_fill_notification_title),
+                    subtitle = stringResource(R.string.autofill_active_fill_notification_desc),
+                    checked = activeFillNotificationEnabled,
+                    onCheckedChange = { enabled ->
+                        scope.launch { preferences.setActiveFillNotificationEnabled(enabled) }
                     },
                 )
                 HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))

--- a/Monica for Android/app/src/main/res/values-zh/strings.xml
+++ b/Monica for Android/app/src/main/res/values-zh/strings.xml
@@ -1886,6 +1886,13 @@
     
     <!-- 自动填充设置 - 填充行为 -->
     <string name="autofill_fill_behavior_title">填充行为</string>
+    <string name="autofill_active_fill_notification_title">主动填充通知</string>
+    <string name="autofill_active_fill_notification_desc">已绑定密码的应用聚焦登录字段时显示通知。需要启用 Monica 无障碍服务并允许通知。</string>
+    <string name="autofill_active_fill_channel_name">自动填充提示</string>
+    <string name="autofill_active_fill_channel_desc">Monica 检测到已绑定登录字段时显示通知</string>
+    <string name="autofill_active_fill_notification_content_title">Monica 可以填充当前应用</string>
+    <string name="autofill_active_fill_notification_content_text">点击选择用于 %1$s 的登录信息</string>
+    <string name="autofill_active_fill_target_unavailable">请返回检测到的应用后重试</string>
     <string name="autofill_fill_verify_identity">填充前验证身份</string>
     <string name="autofill_fill_verify_identity_desc">选择密码后需要指纹或密码验证才能填充</string>
     <string name="autofill_fill_suggestions">填充建议</string>

--- a/Monica for Android/app/src/main/res/values/strings.xml
+++ b/Monica for Android/app/src/main/res/values/strings.xml
@@ -2041,6 +2041,13 @@
     
     <!-- Autofill Settings - Fill Behavior -->
     <string name="autofill_fill_behavior_title">Fill Behavior</string>
+    <string name="autofill_active_fill_notification_title">Proactive fill notification</string>
+    <string name="autofill_active_fill_notification_desc">Show a notification when an app linked to a saved login focuses a sign-in field. Monica Accessibility Service and notification permission are required.</string>
+    <string name="autofill_active_fill_channel_name">Autofill prompts</string>
+    <string name="autofill_active_fill_channel_desc">Notifications for linked sign-in fields detected by Monica</string>
+    <string name="autofill_active_fill_notification_content_title">Monica can fill this app</string>
+    <string name="autofill_active_fill_notification_content_text">Tap to choose a login for %1$s</string>
+    <string name="autofill_active_fill_target_unavailable">Return to the detected app and try again</string>
     <string name="autofill_fill_verify_identity">Verify Before Filling</string>
     <string name="autofill_fill_verify_identity_desc">Verify after choosing a password</string>
     <string name="autofill_fill_suggestions">Fill Suggestions</string>

--- a/Monica for Android/app/src/test/java/takagi/ru/monica/autofill_ng/ActiveFillHardeningRegressionGuardTest.kt
+++ b/Monica for Android/app/src/test/java/takagi/ru/monica/autofill_ng/ActiveFillHardeningRegressionGuardTest.kt
@@ -1,0 +1,61 @@
+package takagi.ru.monica.autofill_ng
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ActiveFillHardeningRegressionGuardTest {
+    @Test
+    fun accessibilityPasteUsesAProtectedTemporaryClipboard() {
+        val serviceSource = projectFile(
+            "app/src/main/java/takagi/ru/monica/service/MonicaAccessibilityService.kt"
+        ).readText()
+
+        assertTrue(serviceSource.contains("android.content.extra.IS_SENSITIVE"))
+        assertTrue(serviceSource.contains("scheduleTemporaryClipboardRestore"))
+        assertTrue(serviceSource.contains("ACTION_SET_SELECTION"))
+        assertTrue(serviceSource.contains("shouldRestoreTemporaryClipboard"))
+    }
+
+    @Test
+    fun notificationFillIsOptInThrottledAndBoundToTheDetectedApp() {
+        val serviceSource = projectFile(
+            "app/src/main/java/takagi/ru/monica/service/MonicaAccessibilityService.kt"
+        ).readText()
+        val helperSource = projectFile(
+            "app/src/main/java/takagi/ru/monica/autofill_ng/ActiveFillNotificationHelper.kt"
+        ).readText()
+        val pickerSource = projectFile(
+            "app/src/main/java/takagi/ru/monica/autofill_ng/AutofillPickerActivityV2.kt"
+        ).readText()
+        val preferencesSource = projectFile(
+            "app/src/main/java/takagi/ru/monica/autofill_ng/AutofillPreferences.kt"
+        ).readText()
+        val settingsScreenSource = projectFile(
+            "app/src/main/java/takagi/ru/monica/ui/screens/AutofillSettingsV2Screen.kt"
+        ).readText()
+
+        assertTrue(serviceSource.contains("activeFillNotificationEnabled"))
+        assertTrue(serviceSource.contains("activeFillPromptThrottle.tryAcquire"))
+        assertTrue(serviceSource.contains("entry.isLinkedToApp(packageName)"))
+        assertFalse(serviceSource.contains("Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE"))
+        assertTrue(helperSource.contains("EXTRA_MANUAL_TARGET_PACKAGE"))
+        assertTrue(pickerSource.contains("EXTRA_MANUAL_TARGET_PACKAGE"))
+        assertTrue(preferencesSource.contains("KEY_ACTIVE_FILL_NOTIFICATION_ENABLED"))
+        assertTrue(preferencesSource.contains("preferences[KEY_ACTIVE_FILL_NOTIFICATION_ENABLED] ?: false"))
+        assertTrue(settingsScreenSource.contains("setActiveFillNotificationEnabled"))
+    }
+
+    private fun projectFile(path: String): File {
+        var dir = File(requireNotNull(System.getProperty("user.dir"))).canonicalFile
+        while (
+            dir.parentFile != null &&
+            !File(dir, "settings.gradle").exists() &&
+            !File(dir, "settings.gradle.kts").exists()
+        ) {
+            dir = dir.parentFile!!.canonicalFile
+        }
+        return File(dir, path)
+    }
+}

--- a/Monica for Android/app/src/test/java/takagi/ru/monica/autofill_ng/ActiveFillPromptThrottleTest.kt
+++ b/Monica for Android/app/src/test/java/takagi/ru/monica/autofill_ng/ActiveFillPromptThrottleTest.kt
@@ -1,0 +1,27 @@
+package takagi.ru.monica.autofill_ng
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ActiveFillPromptThrottleTest {
+    @Test
+    fun throttlesHitsAndMissesPerPackageBeforeWorkStarts() {
+        val throttle = ActiveFillPromptThrottle(throttleMs = 5_000L)
+
+        assertTrue(throttle.tryAcquire("com.example.first", nowMs = 1_000L))
+        assertFalse(throttle.tryAcquire("com.example.first", nowMs = 5_999L))
+        assertTrue(throttle.tryAcquire("com.example.second", nowMs = 2_000L))
+        assertTrue(throttle.tryAcquire("COM.EXAMPLE.FIRST", nowMs = 6_000L))
+    }
+
+    @Test
+    fun clearAllowsAnImmediateFreshPrompt() {
+        val throttle = ActiveFillPromptThrottle(throttleMs = 5_000L)
+
+        assertTrue(throttle.tryAcquire("com.example", nowMs = 1_000L))
+        throttle.clear()
+        assertTrue(throttle.tryAcquire("com.example", nowMs = 1_001L))
+        assertFalse(throttle.tryAcquire("  ", nowMs = 1_002L))
+    }
+}

--- a/Monica for Android/app/src/test/java/takagi/ru/monica/autofill_ng/ManualFillTargetPolicyTest.kt
+++ b/Monica for Android/app/src/test/java/takagi/ru/monica/autofill_ng/ManualFillTargetPolicyTest.kt
@@ -1,0 +1,45 @@
+package takagi.ru.monica.autofill_ng
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ManualFillTargetPolicyTest {
+    @Test
+    fun targetBoundFillWaitsUntilDetectedAppIsActive() {
+        assertNull(
+            resolveManualFillTargetPackage(
+                activePackage = "com.other.app",
+                packageNameToSkip = "takagi.ru.monica",
+                expectedTargetPackage = "com.detected.app",
+            )
+        )
+        assertEquals(
+            "com.detected.app",
+            resolveManualFillTargetPackage(
+                activePackage = "COM.DETECTED.APP",
+                packageNameToSkip = "takagi.ru.monica",
+                expectedTargetPackage = "com.detected.app",
+            )
+        )
+    }
+
+    @Test
+    fun legacyManualEntryKeepsCurrentAppBehavior() {
+        assertEquals(
+            "com.current.app",
+            resolveManualFillTargetPackage(
+                activePackage = "com.current.app",
+                packageNameToSkip = "takagi.ru.monica",
+                expectedTargetPackage = null,
+            )
+        )
+        assertNull(
+            resolveManualFillTargetPackage(
+                activePackage = "takagi.ru.monica",
+                packageNameToSkip = "takagi.ru.monica",
+                expectedTargetPackage = null,
+            )
+        )
+    }
+}

--- a/Monica for Android/app/src/test/java/takagi/ru/monica/service/TemporaryClipboardPolicyTest.kt
+++ b/Monica for Android/app/src/test/java/takagi/ru/monica/service/TemporaryClipboardPolicyTest.kt
@@ -1,0 +1,52 @@
+package takagi.ru.monica.service
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TemporaryClipboardPolicyTest {
+    @Test
+    fun restoresWhenTemporaryClipboardStillMatches() {
+        assertTrue(
+            shouldRestoreTemporaryClipboard(
+                snapshot = TemporaryClipboardSnapshot(
+                    text = "secret",
+                    label = "Monica autofill",
+                    canVerify = true,
+                ),
+                expectedLabel = "Monica autofill",
+                expectedText = "secret",
+            )
+        )
+    }
+
+    @Test
+    fun preservesClipboardWhenUserCopiedSomethingElse() {
+        assertFalse(
+            shouldRestoreTemporaryClipboard(
+                snapshot = TemporaryClipboardSnapshot(
+                    text = "new user content",
+                    label = "User copy",
+                    canVerify = true,
+                ),
+                expectedLabel = "Monica autofill",
+                expectedText = "secret",
+            )
+        )
+    }
+
+    @Test
+    fun restoresOrClearsWhenClipboardCannotBeVerified() {
+        assertTrue(
+            shouldRestoreTemporaryClipboard(
+                snapshot = TemporaryClipboardSnapshot(
+                    text = null,
+                    label = null,
+                    canVerify = false,
+                ),
+                expectedLabel = "Monica autofill",
+                expectedText = "secret",
+            )
+        )
+    }
+}


### PR DESCRIPTION
## 问题背景

部分 App（尤其是使用腾讯 X5/TBS 等自定义内核 WebView 的 H5 登录页，实测如「电影猎手」包名 `qingcore677.mingcore8lc.guanglane1dnx`）在 Monica 自动填充时出现两类问题：

1. 系统 Autofill 框架对该页面返回 `parsedItemCount=0` —— 框架抽不到可填字段；
2. 即便通过无障碍手动触发填充，密码「填进去了但输入框是空的」。

用户实测 **Bitwarden / KeePassDX 能正常填充**，Monica 不能。

## 根因分析

**根因 1：WebView 字段抽取缺失**
`EnhancedAutofillStructureParserV2` 从未调用 `AssistStructure.ViewNode.getHtmlInfo()`，无法从 WebView 的 HTML `<input>` 虚拟节点抽取用户名/密码字段，导致框架侧计为 0 字段。

**根因 2（关键）：`ACTION_SET_TEXT` 对 WebView 无效**
无障碍填充在 `MonicaAccessibilityService.setNodeText()` 中仅使用 `AccessibilityNodeInfo.ACTION_SET_TEXT`。WebView 的 HTML `<input>` 会**接受该 action（返回 true）但不触发 JS 的 `input` 事件**，导致 React/Vue 等前端框架读不到新值、界面保持空白。

这正是 Bitwarden / KeePassDX 能填、Monica 填不进的根本差异 —— **那两家对 WebView 使用的是剪贴板 `ACTION_PASTE`**，粘贴会触发 `input` 事件，H5 框架才能捕获并刷新。

## 修复方案

### 修复 1：WebView 填充改用 `ACTION_PASTE` 优先
文件：`MonicaAccessibilityService.kt` → `setNodeText()`

流程：聚焦目标输入框 → 将凭据写入系统剪贴板 → 执行 `ACTION_PASTE`（触发 `input` 事件，WebView 框架捕获并刷新界面）→ 不支持 paste 的原生 EditText 回退 `ACTION_SET_TEXT`。

> 副作用：填充瞬间会临时覆盖一次剪贴板（Bitwarden 等同样如此，属业界通用做法）。

### 修复 2：主动式无障碍填充提示（针对框架 0 字段的 App）
新增 `ActiveFillNotificationHelper.kt` + 改造 `MonicaAccessibilityService.kt`：
- `onAccessibilityEvent` 放开非浏览器 App，监听 `TYPE_VIEW_FOCUSED`；
- 判断焦点节点是否为登录字段（密码框 / 用户名·邮箱 hint 或 inputType）；
- 后台协程按包名查密码库，若该 App 有匹配条目则发一条通知；
- 点击通知唤起手动选择器（与快捷磁贴入口等价）。

**防误弹设计**：仅当「焦点是登录字段」**且**「密码库有匹配条目」同时满足才提示；聊天框 / 搜索框 / 未存密码的 App 不会弹。

## 改动文件

| 文件 | 改动 |
|---|---|
| `service/MonicaAccessibilityService.kt` | `setNodeText` PASTE 优先 + SET_TEXT 回退（核心修复）；`onServiceConnected` 构造 `PasswordRepository` 并建通知 channel；`onAccessibilityEvent` 放开非浏览器、聚焦登录字段触发主动提示；新增 `maybePromptActiveFill` / `isLikelyLoginField` / 同包节流 |
| `autofill_ng/ActiveFillNotificationHelper.kt`（新增） | 独立通知 channel，点击唤起手动选择器 |

## 测试验证

- 构建 `assembleDebug` 安装到手机；
- 电影猎手登录页点密码框 → 弹 Monica 通知 → 点通知选条目 → **密码框真实出现密码字符**（此前为空白）；
- 日志确认 `setNodeText` 走 PASTE 路径、`filled=true`、目标包名正确。

## 备注

- 无障碍服务被 ROM（如荣耀 MagicOS）回收导致「一会儿自动关闭」属系统行为，非本修复范围；建议将 Monica 加入受保护应用 / 电池不受限。
- 后续可进一步增强框架解析器（补齐 `getHtmlInfo()` 抽取），让纯框架路径覆盖更多 WebView App，彻底减少对无障碍的依赖。
