### PR TITLE
feat(autofill): 主动式无障碍填充通知 + WebView PASTE 优先修复

### DIFF
--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/ActiveFillNotificationHelper.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/ActiveFillNotificationHelper.kt
@@ -1,0 +1,92 @@
+package takagi.ru.monica.autofill_ng
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import takagi.ru.monica.R
+import takagi.ru.monica.autofill_ng.AutofillPickerActivityV2
+
+/**
+ * 主动填充通知（阶段1）：AccessibilityService 检测到某 App 有匹配密码条目时，
+ * 主动发一条通知；点击通知唤起 Monica 手动选择器（与快捷磁贴入口等价）。
+ */
+object ActiveFillNotificationHelper {
+
+    private const val CHANNEL_ID = "active_fill_channel"
+    private const val CHANNEL_NAME = "主动填充提示"
+    private const val NOTIFICATION_ID = 9528
+
+    fun createChannel(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                description = "检测到可填充的登录框时提示"
+            }
+            context.getSystemService(NotificationManager::class.java)
+                ?.createNotificationChannel(channel)
+        }
+    }
+
+    private fun canPost(context: Context): Boolean {
+        val manager = NotificationManagerCompat.from(context)
+        if (!manager.areNotificationsEnabled()) return false
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = context.getSystemService(NotificationManager::class.java)
+                ?.getNotificationChannel(CHANNEL_ID)
+            if (channel != null && channel.importance == NotificationManager.IMPORTANCE_NONE) {
+                return false
+            }
+        }
+        return true
+    }
+
+    fun showActiveFillNotification(context: Context, packageName: String, appName: String): Boolean {
+        createChannel(context)
+        if (!canPost(context)) {
+            android.util.Log.w("ActiveFill", "Notifications unavailable, skip active fill prompt")
+            return false
+        }
+
+        val intent = Intent(context, AutofillPickerActivityV2::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            putExtra(AutofillPickerActivityV2.EXTRA_MANUAL_MODE, true)
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            NOTIFICATION_ID,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_key)
+            .setContentTitle("Monica 可填充")
+            .setContentText("点此为 $appName 填充账号密码")
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .setAutoCancel(true)
+            .setContentIntent(pendingIntent)
+            .setTimeoutAfter(15_000)
+            .build()
+
+        return try {
+            NotificationManagerCompat.from(context).notify(NOTIFICATION_ID, notification)
+            true
+        } catch (e: SecurityException) {
+            android.util.Log.w("ActiveFill", "Notification permission not granted", e)
+            false
+        }
+    }
+
+    fun dismissNotification(context: Context) {
+        NotificationManagerCompat.from(context).cancel(NOTIFICATION_ID)
+    }
+}

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/service/MonicaAccessibilityService.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/service/MonicaAccessibilityService.kt
@@ -11,11 +11,20 @@ import android.text.InputType
 import android.view.accessibility.AccessibilityManager
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.first
+import takagi.ru.monica.data.PasswordDatabase
+import takagi.ru.monica.repository.PasswordRepository
+import takagi.ru.monica.autofill_ng.ActiveFillNotificationHelper
 
 class MonicaAccessibilityService : AccessibilityService() {
     private var lastPackageName: String = ""
     private var lastUrl: String = ""
     private var lastScanTime = 0L
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private lateinit var passwordRepository: PasswordRepository
+    private var lastActiveFillPackage: String = ""
+    private var lastActiveFillTime = 0L
 
     companion object {
         private const val TAG = "MonicaAccessibility"
@@ -28,6 +37,7 @@ class MonicaAccessibilityService : AccessibilityService() {
         private const val SCORE_FOCUSED_BONUS = 12
         private const val SCORE_PASSWORD_FLAG = 90
         private const val SCORE_CONFIRM_PENALTY = 35
+        private const val ACTIVE_FILL_THROTTLE_MS = 5000L
 
         @Volatile
         private var activeInstance: MonicaAccessibilityService? = null
@@ -139,6 +149,12 @@ class MonicaAccessibilityService : AccessibilityService() {
     override fun onServiceConnected() {
         super.onServiceConnected()
         activeInstance = this
+        runCatching {
+            passwordRepository = PasswordRepository(PasswordDatabase.getDatabase(this).passwordEntryDao())
+            ActiveFillNotificationHelper.createChannel(this)
+        }.onFailure { e ->
+            Log.w(TAG, "Failed to init active fill repository", e)
+        }
     }
 
     override fun onAccessibilityEvent(event: AccessibilityEvent?) {
@@ -147,22 +163,29 @@ class MonicaAccessibilityService : AccessibilityService() {
             if (event.eventType !in trackedEventTypes) return
 
             val packageName = event.packageName?.toString().orEmpty()
-            val browserSpec = browserSpecsByPackage[packageName] ?: return
+            val browserSpec = browserSpecsByPackage[packageName]
+            if (browserSpec != null) {
+                val now = System.currentTimeMillis()
+                if (packageName == lastPackageName && now - lastScanTime < SCAN_THROTTLE_MS) return
+                lastScanTime = now
 
-            val now = System.currentTimeMillis()
-            if (packageName == lastPackageName && now - lastScanTime < SCAN_THROTTLE_MS) return
-            lastScanTime = now
+                val root = rootInActiveWindow ?: event.source ?: return
+                val url = findBrowserUrl(root, browserSpec) ?: return
 
-            val root = rootInActiveWindow ?: event.source ?: return
-            val url = findBrowserUrl(root, browserSpec) ?: return
+                if (packageName == lastPackageName && url == lastUrl) return
 
-            if (packageName == lastPackageName && url == lastUrl) return
+                lastPackageName = packageName
+                lastUrl = url
+                BrowserAutofillContextStore.update(packageName, url)
+                ValidatorContextManager.updateContext(packageName, url)
+                Log.d(TAG, "Updated browser context: pkg=$packageName, hasUrl=${url.isNotBlank()}")
+                return
+            }
 
-            lastPackageName = packageName
-            lastUrl = url
-            BrowserAutofillContextStore.update(packageName, url)
-            ValidatorContextManager.updateContext(packageName, url)
-            Log.d(TAG, "Updated browser context: pkg=$packageName, hasUrl=${url.isNotBlank()}")
+            // 阶段1：非浏览器 App 的登录字段聚焦 -> 主动发填充通知
+            if (event.eventType == AccessibilityEvent.TYPE_VIEW_FOCUSED) {
+                maybePromptActiveFill(packageName, event.source)
+            }
         }.onFailure { e ->
             Log.w(TAG, "onAccessibilityEvent failed", e)
         }
@@ -176,6 +199,7 @@ class MonicaAccessibilityService : AccessibilityService() {
         if (activeInstance === this) {
             activeInstance = null
         }
+        serviceScope.cancel()
         super.onDestroy()
     }
 
@@ -253,6 +277,77 @@ class MonicaAccessibilityService : AccessibilityService() {
     }.onFailure { e ->
         Log.w(TAG, "fillCredentialsInActiveWindow failed", e)
     }.getOrDefault(false)
+
+    private fun maybePromptActiveFill(packageName: String, source: AccessibilityNodeInfo?) {
+        if (packageName.isBlank() || source == null) return
+        if (!isLikelyLoginField(source)) return
+
+        val now = System.currentTimeMillis()
+        if (packageName == lastActiveFillPackage && now - lastActiveFillTime < ACTIVE_FILL_THROTTLE_MS) return
+
+        serviceScope.launch {
+            try {
+                val entries = passwordRepository.getAllPasswordEntries().first()
+                val match = entries.firstOrNull { entry ->
+                    entry.appPackageName
+                        .split("[,;| ]".toRegex())
+                        .any { it.equals(packageName, ignoreCase = true) }
+                }
+                if (match != null) {
+                    lastActiveFillPackage = packageName
+                    lastActiveFillTime = now
+                    val shown = ActiveFillNotificationHelper.showActiveFillNotification(
+                        this@MonicaAccessibilityService,
+                        packageName,
+                        match.appName.ifBlank { packageName }
+                    )
+                    Log.d(TAG, "Active fill prompt for pkg=$packageName shown=$shown")
+                } else {
+                    Log.d(TAG, "No matching credential for pkg=$packageName, skip active fill")
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "Active fill query failed", e)
+            }
+        }
+    }
+
+    private fun isLikelyLoginField(node: AccessibilityNodeInfo): Boolean {
+        if (node.isPassword) return true
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            val inputType = node.inputType
+            val inputClass = inputType and InputType.TYPE_MASK_CLASS
+            val variation = inputType and InputType.TYPE_MASK_VARIATION
+            if (
+                (inputClass == InputType.TYPE_CLASS_TEXT && (
+                    variation == InputType.TYPE_TEXT_VARIATION_PASSWORD ||
+                        variation == InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD ||
+                        variation == InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD ||
+                        variation == InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS ||
+                        variation == InputType.TYPE_TEXT_VARIATION_PERSON_NAME ||
+                        variation == InputType.TYPE_TEXT_VARIATION_WEB_EMAIL_ADDRESS
+                    )) ||
+                (inputClass == InputType.TYPE_CLASS_NUMBER &&
+                    variation == InputType.TYPE_NUMBER_VARIATION_PASSWORD)
+            ) {
+                return true
+            }
+        }
+        if (node.isEditable) {
+            val signals = buildList {
+                add(node.hintText?.toString().orEmpty())
+                add(node.contentDescription?.toString().orEmpty())
+                add(node.viewIdResourceName.orEmpty())
+            }.joinToString(" ").lowercase()
+            if (
+                signals.contains("password") || signals.contains("passwd") || signals.contains("pwd") ||
+                signals.contains("username") || signals.contains("user_name") ||
+                signals.contains("email") || signals.contains("login") || signals.contains("account")
+            ) {
+                return true
+            }
+        }
+        return false
+    }
 
     private fun findBrowserUrl(root: AccessibilityNodeInfo, browserSpec: BrowserSpec): String? {
         val queue = ArrayDeque<Pair<AccessibilityNodeInfo, Int>>()
@@ -495,14 +590,33 @@ class MonicaAccessibilityService : AccessibilityService() {
 
     private fun setNodeText(node: AccessibilityNodeInfo?, text: String): Boolean {
         if (node == null || text.isBlank()) return false
+        if (!node.isFocused) {
+            node.performAction(AccessibilityNodeInfo.ACTION_FOCUS)
+        }
+        node.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+
+        // WebView (H5 / X5·TBS 等内核) 的 HTML <input> 对 ACTION_SET_TEXT
+        // 常表现为"接受命令但不刷新界面"——它只改无障碍节点的 text 属性，
+        // 不触发 JS input 事件，框架(React/Vue)因此读不到新值、界面仍空白。
+        // 优先用 ACTION_PASTE：粘贴会触发 input 事件，HTML 框架才能捕获并刷新 UI。
+        // 副作用：临时覆盖系统剪贴板（主流密码管理器的通用做法）。
+        runCatching {
+            val clipboard =
+                getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+            clipboard.setPrimaryClip(
+                android.content.ClipData.newPlainText("monica_fill", text)
+            )
+        }
+        val pasted = runCatching {
+            node.performAction(AccessibilityNodeInfo.ACTION_PASTE)
+        }.getOrDefault(false)
+        if (pasted) return true
+
+        // 原生 EditText 等不支持 paste 的场景，回退 SET_TEXT（原生控件能正确刷新）。
         val args = Bundle().apply {
             putCharSequence(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, text)
         }
         return runCatching {
-            if (!node.isFocused) {
-                node.performAction(AccessibilityNodeInfo.ACTION_FOCUS)
-            }
-            node.performAction(AccessibilityNodeInfo.ACTION_CLICK)
             node.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, args)
         }.getOrDefault(false)
     }


### PR DESCRIPTION
合并两个实质改动（已移除调试 Log.d 提交）：

1. 阶段1 主动式无障碍填充通知 AccessibilityService 现对非浏览器 App 的登录字段聚焦事件， 按包名查询密码库是否有匹配条目；有则发一条通知， 点击唤起手动选择器（与快捷磁贴入口等价）。仅匹配时提示，避免误弹。

2. WebView 填充改用 ACTION_PASTE 优先 原仅用 ACTION_SET_TEXT，对 WebView(H5/X5/TBS) 的 HTML <input> 表现为"接受命令但不刷新界面"——只改无障碍节点 text 属性，不触发 JS input 事件，React/Vue 等框架读不到。 改为 PASTE 优先(触发 input 事件)+ SET_TEXT 回退(原生 EditText)， 对齐 Bitwarden/KeePassDX 的 WebView 填充机制。