### PR TITLE
fix(autofill): 增强 Autofill 兼容性 — 修复小众 App 密码填充与 QQ 搜索框误弹

### DIFF
--- a/Monica for Android/app/src/main/java/takagi/ru/monica/MonicaApplication.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/MonicaApplication.kt
@@ -19,6 +19,7 @@ import takagi.ru.monica.security.AppUpdateSecurityGuard
 import takagi.ru.monica.sync.AndroidSyncNetworkGate
 import takagi.ru.monica.sync.SyncTaskRunner
 import takagi.ru.monica.utils.AppLauncherIconManager
+import takagi.ru.monica.security.SessionManager
 import takagi.ru.monica.utils.SettingsManager
 import takagi.ru.monica.webdav.WebDavBackoffState
 import takagi.ru.monica.workers.KeePassRemoteUploadWorker
@@ -41,6 +42,8 @@ class MonicaApplication : Application() {
     
     override fun onCreate() {
         super.onCreate()
+
+        SessionManager.attachAppContext(this)
 
         AppUpdateSecurityGuard.enforceLockIfAppUpdated(
             context = this,

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/AutofillDetectionPolicy.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/AutofillDetectionPolicy.kt
@@ -37,7 +37,12 @@ internal object AutofillDetectionPolicy {
         hint: FieldHint,
         accuracy: Accuracy,
     ): Boolean {
-        val credentialHint = isAccountHint(hint) || isPasswordHint(hint)
+        // 密码类是强登录信号，即便是低精度（如 VISIBLE_PASSWORD / NUMBER_PASSWORD
+        // 变体映射为 LOW）且当前不可见，也应纳入解析，避免电影猎手这类 App 在聚焦
+        // 账号框时因密码框尚未可见而被整体丢弃、导致密码填充失效。账号类仍需较高
+        // 精度，避免把隐藏的搜索/备注等误判为登录账号（QQ 搜索框修复不受影响）。
+        if (isPasswordHint(hint)) return accuracy.score >= Accuracy.LOWEST.score
+        val credentialHint = isAccountHint(hint)
         return credentialHint && accuracy.score >= Accuracy.MEDIUM.score
     }
 

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/AutofillDetectionPolicy.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/AutofillDetectionPolicy.kt
@@ -22,6 +22,31 @@ internal object AutofillDetectionPolicy {
 
     fun genericNumberFallbackAccuracy(): Accuracy = Accuracy.LOW
 
+    /**
+     * Admission policy used only by the automatic compatibility reparse.
+     * A weak account-like field must carry an explicit login term before it can
+     * be promoted to normal automatic-fill confidence. Manual requests keep
+     * their separate permissive path in [shouldKeepTarget].
+     */
+    fun automaticWeakAccountAccuracy(
+        accuracy: Accuracy,
+        hasLoginTerm: Boolean,
+    ): Accuracy? = when {
+        accuracy.score >= Accuracy.MEDIUM.score -> accuracy
+        hasLoginTerm -> Accuracy.MEDIUM
+        else -> null
+    }
+
+    /**
+     * URL bars are always excluded. Other forced-off signals are controlled by
+     * the user's existing "respect autofill-off" preference.
+     */
+    fun shouldSkipAutofillOffGroup(
+        respectAutofillOff: Boolean,
+        hasForcedOffSignal: Boolean,
+        isAlwaysExcluded: Boolean,
+    ): Boolean = isAlwaysExcluded || (respectAutofillOff && hasForcedOffSignal)
+
     fun shouldKeepTarget(
         hint: FieldHint,
         accuracy: Accuracy,

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/AutofillPickerActivityV2.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/AutofillPickerActivityV2.kt
@@ -7,8 +7,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
 import android.os.Parcelable
 import android.service.autofill.Dataset
 import android.service.autofill.FillResponse
@@ -104,7 +102,6 @@ import takagi.ru.monica.repository.CustomFieldRepository
 import takagi.ru.monica.repository.PasswordRepository
 import takagi.ru.monica.repository.SecureItemRepository
 import takagi.ru.monica.security.SecurityManager
-import takagi.ru.monica.service.MonicaAccessibilityService
 import takagi.ru.monica.ui.theme.MonicaTheme
 import androidx.compose.foundation.isSystemInDarkTheme
 import takagi.ru.monica.data.model.TotpData
@@ -157,9 +154,6 @@ class AutofillPickerActivityV2 : BaseMonicaActivity() {
         const val EXTRA_MANUAL_TARGET_PACKAGE = "extra_manual_target_package"
         const val EXTRA_IME_MODE = "extra_ime_mode"
         private const val DUPLICATE_LAUNCH_WINDOW_MS = 1500L
-        private const val MANUAL_ACCESSIBILITY_FILL_DELAY_MS = 450L
-        private const val MANUAL_ACCESSIBILITY_RETRY_DELAY_MS = 250L
-        private const val MANUAL_ACCESSIBILITY_MAX_ATTEMPTS = 8
         @Volatile
         private var lastLaunchSignature: String? = null
         @Volatile
@@ -648,11 +642,8 @@ class AutofillPickerActivityV2 : BaseMonicaActivity() {
                         finish()
                     }
                     is PasswordAutofillPreparation.Manual -> {
-                        if (scheduleManualAccessibilityFill(preparation.accountValue, preparation.passwordValue)) {
-                            finish()
-                            return@launch
-                        }
-                        copyManualCredentialFallback(preparation.accountValue, preparation.passwordValue)
+                        scheduleManualClipboardFill(preparation.accountValue, preparation.passwordValue)
+                        return@launch
                     }
                     is PasswordAutofillPreparation.Fill -> {
                         val autofillIds = args.autofillIds.orEmpty()
@@ -888,23 +879,13 @@ class AutofillPickerActivityV2 : BaseMonicaActivity() {
         if (password.isBlank()) return
 
         if (isManualMode) {
-            if (scheduleManualAccessibilityFill("", password, preferPasswordField = true)) {
-                finish()
-                return
-            }
-            copyToClipboard(getString(R.string.autofill_password), password, true)
-            finish()
+            scheduleManualClipboardFill("", password)
             return
         }
 
         val autofillIds = args.autofillIds
         if (autofillIds.isNullOrEmpty()) {
-            if (scheduleManualAccessibilityFill("", password, preferPasswordField = true)) {
-                finish()
-            } else {
-                copyToClipboard(getString(R.string.autofill_password), password, true)
-                finish()
-            }
+            scheduleManualClipboardFill("", password)
             return
         }
 
@@ -969,109 +950,11 @@ class AutofillPickerActivityV2 : BaseMonicaActivity() {
         return filledValues
     }
 
-    private fun scheduleManualAccessibilityFill(
-        username: String,
-        password: String,
-        preferPasswordField: Boolean = false,
-        expectedTargetPackage: String? = manualTargetPackage,
-    ): Boolean {
-        if (!MonicaAccessibilityService.isCredentialFillAvailable(applicationContext)) {
-            AutofillLogger.i("PICKER", "Manual accessibility fill unavailable; service is not active")
-            return false
-        }
-
-        val appContext = applicationContext
-        val packageNameToSkip = packageName
-        Handler(Looper.getMainLooper()).postDelayed({
-            requestManualAccessibilityFillWithRetry(
-                appContext = appContext,
-                packageNameToSkip = packageNameToSkip,
-                expectedTargetPackage = expectedTargetPackage,
-                username = username,
-                password = password,
-                preferPasswordField = preferPasswordField,
-                attempt = 1
-            )
-        }, MANUAL_ACCESSIBILITY_FILL_DELAY_MS)
-
-        setResult(Activity.RESULT_CANCELED)
-        moveTaskToBack(true)
-        AutofillLogger.i("PICKER", "Manual accessibility fill scheduled")
+    private fun scheduleManualClipboardFill(username: String, password: String): Boolean {
+        copyManualCredentialFallback(username, password)
         return true
     }
 
-    private fun requestManualAccessibilityFillWithRetry(
-        appContext: Context,
-        packageNameToSkip: String,
-        expectedTargetPackage: String?,
-        username: String,
-        password: String,
-        preferPasswordField: Boolean,
-        attempt: Int,
-    ) {
-        val activePackage = MonicaAccessibilityService.getActiveWindowPackageName().orEmpty()
-        val resolvedTargetPackage = resolveManualFillTargetPackage(
-            activePackage = activePackage,
-            packageNameToSkip = packageNameToSkip,
-            expectedTargetPackage = expectedTargetPackage,
-        )
-        val filled = if (resolvedTargetPackage == null) {
-            false
-        } else {
-            MonicaAccessibilityService.requestCredentialFill(
-                targetPackageName = resolvedTargetPackage,
-                username = username,
-                password = password,
-                preferPasswordField = preferPasswordField
-            )
-        }
-
-        AutofillLogger.i(
-            "PICKER",
-            "Manual accessibility fill attempt: attempt=$attempt, filled=$filled, activePackage=${activePackage.ifBlank { "none" }}, expectedPackage=${expectedTargetPackage.orEmpty().ifBlank { "any" }}"
-        )
-
-        if (filled || attempt >= MANUAL_ACCESSIBILITY_MAX_ATTEMPTS) {
-            if (!filled) {
-                if (!expectedTargetPackage.isNullOrBlank()) {
-                    android.widget.Toast.makeText(
-                        appContext,
-                        R.string.autofill_active_fill_target_unavailable,
-                        android.widget.Toast.LENGTH_SHORT,
-                    ).show()
-                } else if (preferPasswordField && username.isBlank()) {
-                    ClipboardUtils.copyToClipboard(
-                        context = appContext,
-                        text = password,
-                        label = appContext.getString(R.string.autofill_password),
-                        sensitive = true
-                    )
-                    android.widget.Toast.makeText(appContext, R.string.password_copied, android.widget.Toast.LENGTH_SHORT).show()
-                } else {
-                    copyManualCredentialFallback(
-                        context = appContext,
-                        username = username,
-                        password = password,
-                        usernameLabel = appContext.getString(R.string.autofill_username),
-                        passwordLabel = appContext.getString(R.string.autofill_password)
-                    )
-                }
-            }
-            return
-        }
-
-        Handler(Looper.getMainLooper()).postDelayed({
-            requestManualAccessibilityFillWithRetry(
-                appContext = appContext,
-                packageNameToSkip = packageNameToSkip,
-                expectedTargetPackage = expectedTargetPackage,
-                username = username,
-                password = password,
-                preferPasswordField = preferPasswordField,
-                attempt = attempt + 1
-            )
-        }, MANUAL_ACCESSIBILITY_RETRY_DELAY_MS)
-    }
 
     private fun copyManualCredentialFallback(username: String, password: String) {
         copyManualCredentialFallback(

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/AutofillPickerActivityV2.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/AutofillPickerActivityV2.kt
@@ -7,6 +7,8 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.os.Parcelable
 import android.service.autofill.Dataset
 import android.service.autofill.FillResponse
@@ -102,6 +104,7 @@ import takagi.ru.monica.repository.CustomFieldRepository
 import takagi.ru.monica.repository.PasswordRepository
 import takagi.ru.monica.repository.SecureItemRepository
 import takagi.ru.monica.security.SecurityManager
+import takagi.ru.monica.service.MonicaAccessibilityService
 import takagi.ru.monica.ui.theme.MonicaTheme
 import androidx.compose.foundation.isSystemInDarkTheme
 import takagi.ru.monica.data.model.TotpData
@@ -154,6 +157,9 @@ class AutofillPickerActivityV2 : BaseMonicaActivity() {
         const val EXTRA_MANUAL_TARGET_PACKAGE = "extra_manual_target_package"
         const val EXTRA_IME_MODE = "extra_ime_mode"
         private const val DUPLICATE_LAUNCH_WINDOW_MS = 1500L
+        private const val MANUAL_ACCESSIBILITY_FILL_DELAY_MS = 450L
+        private const val MANUAL_ACCESSIBILITY_RETRY_DELAY_MS = 250L
+        private const val MANUAL_ACCESSIBILITY_MAX_ATTEMPTS = 8
         @Volatile
         private var lastLaunchSignature: String? = null
         @Volatile
@@ -642,8 +648,11 @@ class AutofillPickerActivityV2 : BaseMonicaActivity() {
                         finish()
                     }
                     is PasswordAutofillPreparation.Manual -> {
-                        scheduleManualClipboardFill(preparation.accountValue, preparation.passwordValue)
-                        return@launch
+                        if (scheduleManualAccessibilityFill(preparation.accountValue, preparation.passwordValue)) {
+                            finish()
+                            return@launch
+                        }
+                        copyManualCredentialFallback(preparation.accountValue, preparation.passwordValue)
                     }
                     is PasswordAutofillPreparation.Fill -> {
                         val autofillIds = args.autofillIds.orEmpty()
@@ -879,13 +888,23 @@ class AutofillPickerActivityV2 : BaseMonicaActivity() {
         if (password.isBlank()) return
 
         if (isManualMode) {
-            scheduleManualClipboardFill("", password)
+            if (scheduleManualAccessibilityFill("", password, preferPasswordField = true)) {
+                finish()
+                return
+            }
+            copyToClipboard(getString(R.string.autofill_password), password, true)
+            finish()
             return
         }
 
         val autofillIds = args.autofillIds
         if (autofillIds.isNullOrEmpty()) {
-            scheduleManualClipboardFill("", password)
+            if (scheduleManualAccessibilityFill("", password, preferPasswordField = true)) {
+                finish()
+            } else {
+                copyToClipboard(getString(R.string.autofill_password), password, true)
+                finish()
+            }
             return
         }
 
@@ -950,11 +969,115 @@ class AutofillPickerActivityV2 : BaseMonicaActivity() {
         return filledValues
     }
 
-    private fun scheduleManualClipboardFill(username: String, password: String): Boolean {
-        copyManualCredentialFallback(username, password)
+    private fun scheduleManualAccessibilityFill(
+        username: String,
+        password: String,
+        preferPasswordField: Boolean = false,
+        expectedTargetPackage: String? = manualTargetPackage,
+    ): Boolean {
+        if (!MonicaAccessibilityService.isCredentialFillAvailable(applicationContext)) {
+            AutofillLogger.i("PICKER", "Manual accessibility fill unavailable; service is not active")
+            return false
+        }
+
+        val appContext = applicationContext
+        val packageNameToSkip = packageName
+        Handler(Looper.getMainLooper()).postDelayed({
+            requestManualAccessibilityFillWithRetry(
+                appContext = appContext,
+                packageNameToSkip = packageNameToSkip,
+                expectedTargetPackage = expectedTargetPackage,
+                username = username,
+                password = password,
+                preferPasswordField = preferPasswordField,
+                attempt = 1,
+            )
+        }, MANUAL_ACCESSIBILITY_FILL_DELAY_MS)
+
+        setResult(Activity.RESULT_CANCELED)
+        moveTaskToBack(true)
+        AutofillLogger.i("PICKER", "Manual accessibility fill scheduled")
         return true
     }
 
+    private fun requestManualAccessibilityFillWithRetry(
+        appContext: Context,
+        packageNameToSkip: String,
+        expectedTargetPackage: String?,
+        username: String,
+        password: String,
+        preferPasswordField: Boolean,
+        attempt: Int,
+    ) {
+        val activePackage = MonicaAccessibilityService.getActiveWindowPackageName().orEmpty()
+        val resolvedTargetPackage = resolveManualFillTargetPackage(
+            activePackage = activePackage,
+            packageNameToSkip = packageNameToSkip,
+            expectedTargetPackage = expectedTargetPackage,
+        )
+        val filled = if (resolvedTargetPackage == null) {
+            false
+        } else {
+            MonicaAccessibilityService.requestCredentialFill(
+                targetPackageName = resolvedTargetPackage,
+                username = username,
+                password = password,
+                preferPasswordField = preferPasswordField,
+            )
+        }
+
+        AutofillLogger.i(
+            "PICKER",
+            "Manual accessibility fill attempt: attempt=$attempt, filled=$filled, " +
+                "activePackage=${activePackage.ifBlank { "none" }}, " +
+                "expectedPackage=${expectedTargetPackage.orEmpty().ifBlank { "any" }}",
+        )
+
+        if (filled || attempt >= MANUAL_ACCESSIBILITY_MAX_ATTEMPTS) {
+            if (!filled) {
+                if (!expectedTargetPackage.isNullOrBlank()) {
+                    android.widget.Toast.makeText(
+                        appContext,
+                        R.string.autofill_active_fill_target_unavailable,
+                        android.widget.Toast.LENGTH_SHORT,
+                    ).show()
+                } else if (preferPasswordField && username.isBlank()) {
+                    ClipboardUtils.copyToClipboard(
+                        context = appContext,
+                        text = password,
+                        label = appContext.getString(R.string.autofill_password),
+                        sensitive = true,
+                    )
+                    android.widget.Toast.makeText(
+                        appContext,
+                        R.string.password_copied,
+                        android.widget.Toast.LENGTH_SHORT,
+                    ).show()
+                } else {
+                    copyManualCredentialFallback(
+                        context = appContext,
+                        username = username,
+                        password = password,
+                        usernameLabel = appContext.getString(R.string.autofill_username),
+                        passwordLabel = appContext.getString(R.string.autofill_password),
+                    )
+                }
+            }
+            return
+        }
+
+        Handler(Looper.getMainLooper()).postDelayed({
+            requestManualAccessibilityFillWithRetry(
+                appContext = appContext,
+                packageNameToSkip = packageNameToSkip,
+                expectedTargetPackage = expectedTargetPackage,
+                username = username,
+                password = password,
+                preferPasswordField = preferPasswordField,
+                attempt = attempt + 1,
+            )
+        }, MANUAL_ACCESSIBILITY_RETRY_DELAY_MS)
+    }
 
     private fun copyManualCredentialFallback(username: String, password: String) {
         copyManualCredentialFallback(

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/BitwardenLikeAutofillMatcherNg.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/BitwardenLikeAutofillMatcherNg.kt
@@ -215,8 +215,7 @@ class BitwardenLikeAutofillMatcherNg {
                     it == Reason.EXACT_DOMAIN ||
                     it == Reason.SUBDOMAIN ||
                     it == Reason.BASE_DOMAIN ||
-                    it == Reason.EXACT_APP_TITLE ||
-                    it == Reason.PACKAGE_TOKEN_TITLE
+                    it == Reason.EXACT_APP_TITLE
             }
             if (!hasStrongReason) return null
         }

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/BitwardenLikeAutofillMatcherNg.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/BitwardenLikeAutofillMatcherNg.kt
@@ -36,6 +36,15 @@ class BitwardenLikeAutofillMatcherNg {
         val reasons: Set<Reason>,
     )
 
+    companion object {
+        private val PACKAGE_TOKEN_STOPWORDS = setOf(
+            "com", "android", "app", "net", "org", "io",
+            "mobile", "client", "common", "ui", "view", "service",
+            "lib", "utils", "core", "main", "v2", "prod", "dev",
+            "test", "debug",
+        )
+    }
+
     fun match(
         entries: List<PasswordEntry>,
         packageName: String,
@@ -46,9 +55,12 @@ class BitwardenLikeAutofillMatcherNg {
         if (entries.isEmpty()) return emptyList()
 
         val targetPackage = normalizePackageName(packageName)
-        val targetPackageToken = targetPackage
-            ?.substringAfterLast('.')
-            ?.takeIf { it.length >= 2 }
+        val targetPackageTokens = targetPackage
+            ?.split('.')
+            ?.filter { it.length >= 3 }
+            ?.filter { it !in PACKAGE_TOKEN_STOPWORDS }
+            ?.distinct()
+            ?: emptyList()
         val targetHost = normalizeHost(webDomain)
         val preferDomainSignals = !targetHost.isNullOrBlank()
         val targetRoot = targetHost?.let(::extractBaseDomain)
@@ -58,7 +70,7 @@ class BitwardenLikeAutofillMatcherNg {
             scoreEntry(
                 entry = entry,
                 targetPackage = targetPackage,
-                targetPackageToken = targetPackageToken,
+                targetPackageTokens = targetPackageTokens,
                 targetHost = targetHost,
                 preferDomainSignals = preferDomainSignals,
                 targetRoot = targetRoot,
@@ -91,7 +103,7 @@ class BitwardenLikeAutofillMatcherNg {
     private fun scoreEntry(
         entry: PasswordEntry,
         targetPackage: String?,
-        targetPackageToken: String?,
+        targetPackageTokens: List<String>,
         targetHost: String?,
         preferDomainSignals: Boolean,
         targetRoot: String?,
@@ -133,9 +145,10 @@ class BitwardenLikeAutofillMatcherNg {
             reasons += Reason.EXACT_APP_TITLE
         }
 
-        if (!preferDomainSignals && config.allowPackageMatch && !targetPackageToken.isNullOrBlank()) {
-            val token = targetPackageToken.lowercase(Locale.ROOT)
-            val tokenMatched = entryTitle.contains(token) || entryAppName.contains(token)
+        if (!preferDomainSignals && config.allowPackageMatch && targetPackageTokens.isNotEmpty()) {
+            val tokenMatched = targetPackageTokens.any { token ->
+                entryTitle.contains(token) || entryAppName.contains(token)
+            }
             if (tokenMatched) {
                 score += 70
                 reasons += Reason.PACKAGE_TOKEN_TITLE
@@ -202,7 +215,8 @@ class BitwardenLikeAutofillMatcherNg {
                     it == Reason.EXACT_DOMAIN ||
                     it == Reason.SUBDOMAIN ||
                     it == Reason.BASE_DOMAIN ||
-                    it == Reason.EXACT_APP_TITLE
+                    it == Reason.EXACT_APP_TITLE ||
+                    it == Reason.PACKAGE_TOKEN_TITLE
             }
             if (!hasStrongReason) return null
         }

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
@@ -117,6 +117,8 @@ class EnhancedAutofillStructureParserV2 {
         val isFocused: Boolean = false,
         val isVisible: Boolean = true,
         val traversalIndex: Int = 0,
+        val hasPasswordTerm: Boolean = false,
+        val hasLoginTerm: Boolean = false,
     )
 
     private data class ParsedItemBuilder(
@@ -166,6 +168,29 @@ class EnhancedAutofillStructureParserV2 {
         "passe",
         "密码",
         "密碼",
+    )
+
+    private val autofillLabelLoginTranslations = listOf(
+        "username",
+        "login",
+        "account",
+        "用户名",
+        "用戶名",
+        "账号",
+        "帳號",
+        "账户",
+        "账户",
+        "登录",
+        "登錄",
+        "логин",
+        "логін",
+        "identifiant",
+        "utilisateur",
+        "kullanıcı",
+        "用户",
+        "密码",
+        "密碼",
+        "password",
     )
 
     private val autofillLabel2faTranslations = listOf(
@@ -499,7 +524,6 @@ class EnhancedAutofillStructureParserV2 {
         structure: AssistStructure,
         respectAutofillOff: Boolean = true,
         allowWeakTargets: Boolean = false,
-        knownLoginPackage: Boolean = false,
     ): ParsedStructure {
         var applicationId: String? = structure.activityComponent?.packageName
         var rawStructure: RawParsedStructure? = null
@@ -567,18 +591,27 @@ class EnhancedAutofillStructureParserV2 {
         // （由普通文本框/数字框弱推断而来）不应被视为登录目标，
         // 否则会把搜索框、备注等误判为账号（如 QQ 搜索框弹出密码条目）。
         // 高置信度的账号字段（如显式 autofill hint）即使无密码也保留。
-        val hasPasswordInItems = confidenceFilteredItems.any {
+        //
+        // 弱目标模式（allowWeakTargets=true，对齐 bitwarden 的"有 Login 字段就 Fillable"门槛）：
+        // 1. 先用 promotePasswordTermCandidates 尝试从候选里按 password 术语提升出密码字段；
+        //    提升成功则 hasPasswordInItems=true，低精度账号字段自然保留并弹窗。
+        // 2. 提升失败时，若屏幕上有任意 login 术语（username/账号/password/密码 等），
+        //    仍放行低精度账号字段——bitwarden 式门槛，确保电影猎手「密码框不在结构里、
+        //    只有账号框」时仍弹账号面板。无 login 术语的纯搜索/备注场景不放行，缓解误弹。
+        val effectiveItems = if (allowWeakTargets) {
+            promotePasswordTermCandidates(confidenceFilteredItems)
+        } else {
+            confidenceFilteredItems
+        }
+        val hasPasswordInItems = effectiveItems.any {
             it.hint == InternalHint.PASSWORD || it.hint == InternalHint.NEW_PASSWORD
         }
-        // 已知登录包（历史上出现过密码框）在弱目标模式下放行低精度账号字段：
-        // 这类 App（如影视类自定义登录框、电影猎手）的账号框常被弱推断为低精度 USERNAME，
-        // 且密码框在聚焦账号框时可能尚未可见/未被识别，首轮保守解析会丢弃全部字段导致不弹面板。
-        // 此处仅对「已知登录包」放宽，未知包（如 QQ 搜索框）仍按原逻辑过滤，避免误弹非登录弱推断字段。
-        // 放行的字段最终仍会经过上层 selectFillableTargets（isSupportedFillableHint + shouldKeepTarget）过滤。
-        val allowWeakLoginTargets = allowWeakTargets && knownLoginPackage
+        val weakLoginContext = allowWeakTargets && !hasPasswordInItems &&
+            candidateItems.any { it.hasPasswordTerm || it.hasLoginTerm }
         val loginFilteredItems = when {
-            hasPasswordInItems || allowWeakLoginTargets -> confidenceFilteredItems
-            else -> confidenceFilteredItems.filterNot {
+            hasPasswordInItems -> effectiveItems
+            weakLoginContext -> effectiveItems
+            else -> effectiveItems.filterNot {
                 (it.hint == InternalHint.USERNAME ||
                     it.hint == InternalHint.EMAIL_ADDRESS ||
                     it.hint == InternalHint.PHONE_NUMBER) &&
@@ -596,8 +629,9 @@ class EnhancedAutofillStructureParserV2 {
                 "loginFilteredCount" to loginFilteredItems.size,
                 "candidates" to candidateItems.joinToString { "${it.hint}:${it.accuracy.name}" },
                 "allowWeakTargets" to allowWeakTargets,
-                "knownLoginPackage" to knownLoginPackage,
-                "allowWeakLoginTargets" to allowWeakLoginTargets,
+                "promotedPasswordCount" to (effectiveItems.size - confidenceFilteredItems.size).coerceAtLeast(0),
+                "hasPasswordInItems" to hasPasswordInItems,
+                "weakLoginContext" to weakLoginContext,
             )
         )
         loginFilteredItems
@@ -837,6 +871,8 @@ class EnhancedAutofillStructureParserV2 {
             outBuilders += inputOut + labelOut
 
             if (node.visibility == View.VISIBLE || shouldIncludeHiddenCredentialNode(outBuilders)) {
+                val nodeHasPasswordTerm = nodeHasPasswordTermMatch(node)
+                val nodeHasLoginTerm = nodeHasLoginTermMatch(node)
                 out += outBuilders.map { builder ->
                     context.traversalIndex += 1
                     RawParsedItem(
@@ -852,6 +888,8 @@ class EnhancedAutofillStructureParserV2 {
                         isFocused = node.isFocused,
                         isVisible = node.visibility == View.VISIBLE,
                         traversalIndex = context.traversalIndex,
+                        hasPasswordTerm = nodeHasPasswordTerm,
+                        hasLoginTerm = nodeHasLoginTerm,
                     )
                 }
             }
@@ -1497,6 +1535,83 @@ class EnhancedAutofillStructureParserV2 {
                 hint = mappedHint,
                 accuracy = builder.accuracy,
             )
+        }
+    }
+
+    /**
+     * 判断节点的文本信号（idEntry / label hint / autofillHints / html placeholder / className）
+     * 是否含 password 术语。用于弱目标模式下把非标准 inputType 的密码框从 USERNAME:LOWEST
+     * 提升为 PASSWORD（借鉴 bitwarden 的 updateForMissingPasswordFields）。
+     */
+    private fun nodeHasPasswordTermMatch(node: AssistStructure.ViewNode): Boolean {
+        val candidates = buildList {
+            node.idEntry?.let { add(it) }
+            node.hint?.toString()?.let { add(it) }
+            node.autofillHints?.forEach { add(it) }
+            node.htmlInfo?.attributes?.forEach { (k, v) ->
+                if (k.equals("placeholder", ignoreCase = true) ||
+                    k.equals("name", ignoreCase = true) ||
+                    k.equals("id", ignoreCase = true)
+                ) {
+                    v?.let { add(it) }
+                }
+            }
+            node.className?.let { add(it) }
+        }
+        return candidates.any { value ->
+            autofillLabelPasswordTranslations.any { term -> value.contains(term, ignoreCase = true) }
+        }
+    }
+
+    /**
+     * 判断节点的文本信号是否含 login 术语（username/login/账号/用户名/password/密码 等）。
+     * 用于弱目标模式下的「login 上下文门」：无密码框时，若屏幕上任意节点含 login 术语，
+     * 放行低精度账号字段（对齐 bitwarden「有 Login 字段就 Fillable」门槛）；
+     * 纯搜索/备注场景无 login 术语，不放行，缓解误弹。
+     */
+    private fun nodeHasLoginTermMatch(node: AssistStructure.ViewNode): Boolean {
+        val candidates = buildList {
+            node.idEntry?.let { add(it) }
+            node.hint?.toString()?.let { add(it) }
+            node.autofillHints?.forEach { add(it) }
+            node.htmlInfo?.attributes?.forEach { (k, v) ->
+                if (k.equals("placeholder", ignoreCase = true) ||
+                    k.equals("name", ignoreCase = true) ||
+                    k.equals("id", ignoreCase = true)
+                ) {
+                    v?.let { add(it) }
+                }
+            }
+        }
+        return candidates.any { value ->
+            autofillLabelLoginTranslations.any { term -> value.contains(term, ignoreCase = true) }
+        }
+    }
+
+    /**
+     * 弱目标模式下的密码字段提升（借鉴 bitwarden updateForMissingPasswordFields）：
+     * 当候选里无 PASSWORD 时，把含 password 术语但被识别为其它 hint（通常是 USERNAME:LOWEST，
+     * 因 inputType 非标准所致）的候选提升为 PASSWORD:LOW。提升后 hasPasswordInItems=true，
+     * 低精度账号字段自然保留并弹窗；无 password 术语的（如 QQ 搜索框）不受影响，仍按原逻辑过滤。
+     * 仅在 allowWeakTargets=true 时调用。
+     */
+    private fun promotePasswordTermCandidates(items: List<RawParsedItem>): List<RawParsedItem> {
+        val hasPassword = items.any {
+            it.hint == InternalHint.PASSWORD || it.hint == InternalHint.NEW_PASSWORD
+        }
+        if (hasPassword) return items
+        val anyPromotable = items.any { it.hasPasswordTerm && it.hint != InternalHint.OFF }
+        if (!anyPromotable) return items
+        return items.map { item ->
+            if (item.hasPasswordTerm &&
+                item.hint != InternalHint.OFF &&
+                item.hint != InternalHint.PASSWORD &&
+                item.hint != InternalHint.NEW_PASSWORD
+            ) {
+                item.copy(hint = InternalHint.PASSWORD, accuracy = Accuracy.LOW)
+            } else {
+                item
+            }
         }
     }
 

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
@@ -1472,10 +1472,19 @@ class EnhancedAutofillStructureParserV2 {
                         InputType.TYPE_TEXT_VARIATION_PERSON_NAME,
                         InputType.TYPE_TEXT_VARIATION_WEB_EDIT_TEXT,
                     ) -> {
-                        out += ParsedItemBuilder(
-                            accuracy = Accuracy.LOWEST,
-                            hint = InternalHint.USERNAME,
-                        )
+                        // 对齐 bitwarden：纯 text 变体不再无条件 fallback 为 USERNAME:LOWEST
+                        // （bitwarden 的 toAutofillView 对纯 text 返回 Unused）。
+                        // 仅当 idEntry / idType 含 username 术语时才产出 USERNAME（由
+                        // extractOfId/extractOfType 按术语定 MEDIUM 精度），避免把
+                        // 搜索框/备注等纯文本框误判为登录账号（QQ 搜索框误弹修复）。
+                        // WEB_EDIT_TEXT 变体（WebView 内可编辑文本）保留 LOWEST fallback，
+                        // 因 WebView 登录框常用该变体且无标准 hint。
+                        if (inputIsVariationType(inputType, InputType.TYPE_TEXT_VARIATION_WEB_EDIT_TEXT)) {
+                            out += ParsedItemBuilder(
+                                accuracy = Accuracy.LOWEST,
+                                hint = InternalHint.USERNAME,
+                            )
+                        }
                         extractOfType(node.idType.orEmpty()).let(out::addAll)
                         extractOfId(node.idEntry.orEmpty()).let(out::addAll)
                     }

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
@@ -499,6 +499,7 @@ class EnhancedAutofillStructureParserV2 {
         structure: AssistStructure,
         respectAutofillOff: Boolean = true,
         allowWeakTargets: Boolean = false,
+        knownLoginPackage: Boolean = false,
     ): ParsedStructure {
         var applicationId: String? = structure.activityComponent?.packageName
         var rawStructure: RawParsedStructure? = null
@@ -569,10 +570,15 @@ class EnhancedAutofillStructureParserV2 {
         val hasPasswordInItems = confidenceFilteredItems.any {
             it.hint == InternalHint.PASSWORD || it.hint == InternalHint.NEW_PASSWORD
         }
-        val loginFilteredItems = if (hasPasswordInItems) {
-            confidenceFilteredItems
-        } else {
-            confidenceFilteredItems.filterNot {
+        // 已知登录包（历史上出现过密码框）在弱目标模式下放行低精度账号字段：
+        // 这类 App（如影视类自定义登录框、电影猎手）的账号框常被弱推断为低精度 USERNAME，
+        // 且密码框在聚焦账号框时可能尚未可见/未被识别，首轮保守解析会丢弃全部字段导致不弹面板。
+        // 此处仅对「已知登录包」放宽，未知包（如 QQ 搜索框）仍按原逻辑过滤，避免误弹非登录弱推断字段。
+        // 放行的字段最终仍会经过上层 selectFillableTargets（isSupportedFillableHint + shouldKeepTarget）过滤。
+        val allowWeakLoginTargets = allowWeakTargets && knownLoginPackage
+        val loginFilteredItems = when {
+            hasPasswordInItems || allowWeakLoginTargets -> confidenceFilteredItems
+            else -> confidenceFilteredItems.filterNot {
                 (it.hint == InternalHint.USERNAME ||
                     it.hint == InternalHint.EMAIL_ADDRESS ||
                     it.hint == InternalHint.PHONE_NUMBER) &&
@@ -590,6 +596,8 @@ class EnhancedAutofillStructureParserV2 {
                 "loginFilteredCount" to loginFilteredItems.size,
                 "candidates" to candidateItems.joinToString { "${it.hint}:${it.accuracy.name}" },
                 "allowWeakTargets" to allowWeakTargets,
+                "knownLoginPackage" to knownLoginPackage,
+                "allowWeakLoginTargets" to allowWeakLoginTargets,
             )
         )
         loginFilteredItems

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
@@ -581,6 +581,12 @@ class EnhancedAutofillStructureParserV2 {
         }
 
         val items = mutableListOf<ParsedItem>()
+        Log.d(
+            "MonicaAutofill",
+            "DIAG confidenceFiltered.size=${confidenceFilteredItems.size} " +
+                "loginFiltered.size=${loginFilteredItems.size} " +
+                "candidates=[${candidateItems.joinToString { "${it.hint}:${it.accuracy.name}" }}]"
+        )
         loginFilteredItems
             .groupBy { it.id }
             .forEach { groupedById ->
@@ -710,7 +716,8 @@ class EnhancedAutofillStructureParserV2 {
             "parse result: items=${items.size}, totalNodes=${parseContext.totalNodesVisited}, " +
                 "withAutofillId=${parseContext.nodesWithAutofillId}, " +
                 "withoutAutofillId=${parseContext.nodesWithoutAutofillId}, " +
-                "webDomain=$effectiveWebDomain, webScheme=${rawStructure?.webScheme}"
+                "webDomain=$effectiveWebDomain, webScheme=${rawStructure?.webScheme}, " +
+                "itemHints=[${items.joinToString { "${it.hint}:${it.accuracy.name}" }}]"
         )
 
         return ParsedStructure(

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
@@ -587,17 +587,16 @@ class EnhancedAutofillStructureParserV2 {
             }
         }
 
-        // 登录上下文约束：屏幕上不存在密码框时，低置信度的账号类字段
-        // （由普通文本框/数字框弱推断而来）不应被视为登录目标，
-        // 否则会把搜索框、备注等误判为账号（如 QQ 搜索框弹出密码条目）。
-        // 高置信度的账号字段（如显式 autofill hint）即使无密码也保留。
-        //
-        // 弱目标模式（allowWeakTargets=true，对齐 bitwarden 的"有 Login 字段就 Fillable"门槛）：
+        // 弱目标模式（allowWeakTargets=true，对齐 bitwarden「有 Login 字段就 Fillable」门槛）：
         // 1. 先用 promotePasswordTermCandidates 尝试从候选里按 password 术语提升出密码字段；
         //    提升成功则 hasPasswordInItems=true，低精度账号字段自然保留并弹窗。
-        // 2. 提升失败时，若屏幕上有任意 login 术语（username/账号/password/密码 等），
-        //    仍放行低精度账号字段——bitwarden 式门槛，确保电影猎手「密码框不在结构里、
-        //    只有账号框」时仍弹账号面板。无 login 术语的纯搜索/备注场景不放行，缓解误弹。
+        // 2. 提升后仍无密码框时，若候选中存在任意已被识别为 Login 类型的字段
+        //    （USERNAME/EMAIL/PHONE，不论精度），放行低精度账号字段，弹账号面板。
+        //    这对齐 bitwarden 的「有 Login.Username 就 Fillable」逻辑——bitwarden 不在
+        //    弹窗决策层做「无密码框时过滤低精度账号」的二次保险，而是靠前置的字段识别
+        //    阶段把搜索框等判为 Unused。Monica 的 TYPE_TEXT_VARIATION_NORMAL fallback
+        //    比 bitwarden 宽松（会把纯 text 判为 USERNAME:LOWEST），但电影猎手等真登录
+        //    场景的确定 bug优先于假设性的搜索框误弹（后者可用黑名单兜底）。
         val effectiveItems = if (allowWeakTargets) {
             promotePasswordTermCandidates(confidenceFilteredItems)
         } else {
@@ -606,8 +605,12 @@ class EnhancedAutofillStructureParserV2 {
         val hasPasswordInItems = effectiveItems.any {
             it.hint == InternalHint.PASSWORD || it.hint == InternalHint.NEW_PASSWORD
         }
-        val weakLoginContext = allowWeakTargets && !hasPasswordInItems &&
-            candidateItems.any { it.hasPasswordTerm || it.hasLoginTerm }
+        val hasLoginTypeField = effectiveItems.any {
+            it.hint == InternalHint.USERNAME ||
+                it.hint == InternalHint.EMAIL_ADDRESS ||
+                it.hint == InternalHint.PHONE_NUMBER
+        }
+        val weakLoginContext = allowWeakTargets && !hasPasswordInItems && hasLoginTypeField
         val loginFilteredItems = when {
             hasPasswordInItems -> effectiveItems
             weakLoginContext -> effectiveItems
@@ -631,6 +634,7 @@ class EnhancedAutofillStructureParserV2 {
                 "allowWeakTargets" to allowWeakTargets,
                 "promotedPasswordCount" to (effectiveItems.size - confidenceFilteredItems.size).coerceAtLeast(0),
                 "hasPasswordInItems" to hasPasswordInItems,
+                "hasLoginTypeField" to hasLoginTypeField,
                 "weakLoginContext" to weakLoginContext,
             )
         )
@@ -873,6 +877,30 @@ class EnhancedAutofillStructureParserV2 {
             if (node.visibility == View.VISIBLE || shouldIncludeHiddenCredentialNode(outBuilders)) {
                 val nodeHasPasswordTerm = nodeHasPasswordTermMatch(node)
                 val nodeHasLoginTerm = nodeHasLoginTermMatch(node)
+                // 诊断：当节点被识别为 LOWEST 精度的 USERNAME（纯 text fallback 路径）时，
+                // 记录其原始信号，用于排查电影猎手等 App 的账号框为何被弱推断、
+                // 以及 bitwarden 等为何能识别（对比 autofillHints/idEntry/hint/inputType）。
+                if (outBuilders.any { it.hint == InternalHint.USERNAME &&
+                    it.accuracy == Accuracy.LOWEST }) {
+                    AutofillLogger.d(
+                        "PARSING",
+                        "LOWEST username node signals",
+                        metadata = mapOf(
+                            "className" to (node.className ?: "none"),
+                            "inputType" to node.inputType.toString(),
+                            "autofillHints" to (node.autofillHints?.joinToString(",") ?: "none"),
+                            "idEntry" to (node.idEntry ?: "none"),
+                            "hintLabel" to (node.hint?.toString() ?: "none"),
+                            "hasPasswordTerm" to nodeHasPasswordTerm,
+                            "hasLoginTerm" to nodeHasLoginTerm,
+                            "htmlTag" to (node.htmlInfo?.tag ?: "none"),
+                            "htmlAttrs" to (node.htmlInfo?.attributes
+                                ?.joinToString(",") { "${it.first}=${it.second}" } ?: "none"),
+                            "isVisible" to (node.visibility == View.VISIBLE),
+                            "isFocused" to node.isFocused,
+                        ),
+                    )
+                }
                 out += outBuilders.map { builder ->
                     context.traversalIndex += 1
                     RawParsedItem(

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
@@ -1385,22 +1385,13 @@ class EnhancedAutofillStructureParserV2 {
                         inputType,
                         InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD,
                     ) -> {
-                        val hasUsername = out.any {
-                            it.hint == InternalHint.USERNAME ||
-                                it.hint == InternalHint.EMAIL_ADDRESS ||
-                                it.hint == InternalHint.PHONE_NUMBER
-                        }
-                        if (hasUsername) {
-                            out += ParsedItemBuilder(
-                                accuracy = Accuracy.LOWEST,
-                                hint = InternalHint.PASSWORD,
-                            )
-                        } else {
-                            out += ParsedItemBuilder(
-                                accuracy = Accuracy.LOWEST,
-                                hint = InternalHint.USERNAME,
-                            )
-                        }
+                        // 可见密码变体一定是密码框（如"显示密码"切换），
+                        // 原逻辑要求同节点已存在 username 才判定为 password，
+                        // 但账号/密码通常是独立节点，导致密码框被误判为 username。
+                        out += ParsedItemBuilder(
+                            accuracy = Accuracy.LOW,
+                            hint = InternalHint.PASSWORD,
+                        )
                     }
 
                     inputIsVariationType(

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
@@ -546,21 +546,16 @@ class EnhancedAutofillStructureParserV2 {
                 return@let list
             }
 
-            val hasUsernameAndPassword =
-                list.any {
-                    val usernameLike =
-                        it.hint == InternalHint.USERNAME ||
-                            it.hint == InternalHint.EMAIL_ADDRESS ||
-                            it.hint == InternalHint.PHONE_NUMBER
-                    usernameLike && it.accuracy.score > Accuracy.LOWEST.score
-                } &&
-                    list.any {
-                        val passwordLike =
-                            it.hint == InternalHint.PASSWORD ||
-                                it.hint == InternalHint.NEW_PASSWORD
-                        passwordLike && it.accuracy.score > Accuracy.LOWEST.score
-                    }
-            if (hasUsernameAndPassword) {
+            // 全 LOW 精度时，只要有密码框（即使账号框精度低/缺失）就保留所有字段，
+            // 登录场景的关键判定信号是密码框而非账号框。纯搜索框/备注等（无密码框）
+            // 仍返回空，不会误弹密码建议（如 QQ 搜索框）。
+            val hasPasswordLike = list.any {
+                val passwordLike =
+                    it.hint == InternalHint.PASSWORD ||
+                        it.hint == InternalHint.NEW_PASSWORD
+                passwordLike && it.accuracy.score > Accuracy.LOWEST.score
+            }
+            if (hasPasswordLike) {
                 list
             } else {
                 emptyList()

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
@@ -567,8 +567,26 @@ class EnhancedAutofillStructureParserV2 {
             }
         }
 
+        // 登录上下文约束：屏幕上不存在密码框时，低置信度的账号类字段
+        // （由普通文本框/数字框弱推断而来）不应被视为登录目标，
+        // 否则会把搜索框、备注等误判为账号（如 QQ 搜索框弹出密码条目）。
+        // 高置信度的账号字段（如显式 autofill hint）即使无密码也保留。
+        val hasPasswordInItems = confidenceFilteredItems.any {
+            it.hint == InternalHint.PASSWORD || it.hint == InternalHint.NEW_PASSWORD
+        }
+        val loginFilteredItems = if (hasPasswordInItems) {
+            confidenceFilteredItems
+        } else {
+            confidenceFilteredItems.filterNot {
+                (it.hint == InternalHint.USERNAME ||
+                    it.hint == InternalHint.EMAIL_ADDRESS ||
+                    it.hint == InternalHint.PHONE_NUMBER) &&
+                    it.accuracy.score < Accuracy.MEDIUM.score
+            }
+        }
+
         val items = mutableListOf<ParsedItem>()
-        confidenceFilteredItems
+        loginFilteredItems
             .groupBy { it.id }
             .forEach { groupedById ->
                 val forceAutofillOff = groupedById.value.any {

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
@@ -1548,12 +1548,13 @@ class EnhancedAutofillStructureParserV2 {
             node.idEntry?.let { add(it) }
             node.hint?.toString()?.let { add(it) }
             node.autofillHints?.forEach { add(it) }
-            node.htmlInfo?.attributes?.forEach { (k, v) ->
+            node.htmlInfo?.attributes?.forEach { attr ->
+                val k = attr.first
                 if (k.equals("placeholder", ignoreCase = true) ||
                     k.equals("name", ignoreCase = true) ||
                     k.equals("id", ignoreCase = true)
                 ) {
-                    v?.let { add(it) }
+                    attr.second?.let { add(it) }
                 }
             }
             node.className?.let { add(it) }
@@ -1574,12 +1575,13 @@ class EnhancedAutofillStructureParserV2 {
             node.idEntry?.let { add(it) }
             node.hint?.toString()?.let { add(it) }
             node.autofillHints?.forEach { add(it) }
-            node.htmlInfo?.attributes?.forEach { (k, v) ->
+            node.htmlInfo?.attributes?.forEach { attr ->
+                val k = attr.first
                 if (k.equals("placeholder", ignoreCase = true) ||
                     k.equals("name", ignoreCase = true) ||
                     k.equals("id", ignoreCase = true)
                 ) {
-                    v?.let { add(it) }
+                    attr.second?.let { add(it) }
                 }
             }
         }

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
@@ -581,11 +581,16 @@ class EnhancedAutofillStructureParserV2 {
         }
 
         val items = mutableListOf<ParsedItem>()
-        Log.d(
-            "MonicaAutofill",
-            "DIAG confidenceFiltered.size=${confidenceFilteredItems.size} " +
-                "loginFiltered.size=${loginFilteredItems.size} " +
-                "candidates=[${candidateItems.joinToString { "${it.hint}:${it.accuracy.name}" }}]"
+        AutofillLogger.d(
+            "PARSING",
+            "Parser field selection",
+            metadata = mapOf(
+                "candidateCount" to candidateItems.size,
+                "confidenceFilteredCount" to confidenceFilteredItems.size,
+                "loginFilteredCount" to loginFilteredItems.size,
+                "candidates" to candidateItems.joinToString { "${it.hint}:${it.accuracy.name}" },
+                "allowWeakTargets" to allowWeakTargets,
+            )
         )
         loginFilteredItems
             .groupBy { it.id }

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
@@ -641,11 +641,17 @@ class EnhancedAutofillStructureParserV2 {
         loginFilteredItems
             .groupBy { it.id }
             .forEach { groupedById ->
+                val groupHints = groupedById.value.joinToString { "${it.hint}:${it.accuracy.name}" }
                 val forceAutofillOff = groupedById.value.any {
                     it.hint == InternalHint.OFF && it.accuracy == Accuracy.HIGHEST
                 }
                 var structureItems = if (forceAutofillOff) {
-                    return@forEach
+                    // importantForAutofill=NO 的节点（OFF:HIGHEST）应跳过，
+                    // 但若同 id 组有来自其它信号（autofillHints/html）的非 OFF 候选
+                    // （如 EMAIL/PHONE/PASSWORD），应保留这些非 OFF 候选而非整组跳过。
+                    // 否则电影猎手等 App 的重要ForAutofill=NO 节点会连带丢弃同组的有效字段。
+                    val nonOff = groupedById.value.filter { it.hint != InternalHint.OFF }
+                    if (nonOff.isNotEmpty()) nonOff else return@forEach
                 } else if (respectAutofillOff) {
                     if (groupedById.value.any { it.hint == InternalHint.OFF }) {
                         return@forEach
@@ -749,6 +755,28 @@ class EnhancedAutofillStructureParserV2 {
                     traversalIndex = selectedItem.traversalIndex,
                 )
             }
+
+        // 诊断：记录 groupBy 后每组被跳过的原因，排查 loginFilteredCount>0 但 parsedItems=0
+        if (loginFilteredItems.isNotEmpty() && items.isEmpty()) {
+            val groupDiagnostics = loginFilteredItems
+                .groupBy { it.id }
+                .map { (id, group) ->
+                    val hints = group.joinToString { "${it.hint}:${it.accuracy.name}" }
+                    val hasOff = group.any { it.hint == InternalHint.OFF }
+                    val mappedHints = group.mapNotNull { mapHint(it.hint) }
+                    "id=$id hints=[$hints] hasOff=$hasOff mappedCount=${mappedHints.size}"
+                }
+            AutofillLogger.w(
+                "PARSING",
+                "All groups skipped after groupBy despite non-empty loginFilteredItems",
+                metadata = mapOf(
+                    "loginFilteredCount" to loginFilteredItems.size,
+                    "groupCount" to groupDiagnostics.size,
+                    "respectAutofillOff" to respectAutofillOff,
+                    "groups" to groupDiagnostics.joinToString(" | "),
+                ),
+            )
+        }
 
         val isInSelfHostedServer = kotlin.run {
             val webDomain = rawStructure?.webDomain

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt
@@ -179,7 +179,7 @@ class EnhancedAutofillStructureParserV2 {
         "账号",
         "帳號",
         "账户",
-        "账户",
+        "賬戶",
         "登录",
         "登錄",
         "логин",
@@ -187,10 +187,6 @@ class EnhancedAutofillStructureParserV2 {
         "identifiant",
         "utilisateur",
         "kullanıcı",
-        "用户",
-        "密码",
-        "密碼",
-        "password",
     )
 
     private val autofillLabel2faTranslations = listOf(
@@ -524,6 +520,7 @@ class EnhancedAutofillStructureParserV2 {
         structure: AssistStructure,
         respectAutofillOff: Boolean = true,
         allowWeakTargets: Boolean = false,
+        requireExplicitWeakLoginSignal: Boolean = false,
     ): ParsedStructure {
         var applicationId: String? = structure.activityComponent?.packageName
         var rawStructure: RawParsedStructure? = null
@@ -587,20 +584,19 @@ class EnhancedAutofillStructureParserV2 {
             }
         }
 
-        // 弱目标模式（allowWeakTargets=true，对齐 bitwarden「有 Login 字段就 Fillable」门槛）：
-        // 1. 先用 promotePasswordTermCandidates 尝试从候选里按 password 术语提升出密码字段；
-        //    提升成功则 hasPasswordInItems=true，低精度账号字段自然保留并弹窗。
-        // 2. 提升后仍无密码框时，若候选中存在任意已被识别为 Login 类型的字段
-        //    （USERNAME/EMAIL/PHONE，不论精度），放行低精度账号字段，弹账号面板。
-        //    这对齐 bitwarden 的「有 Login.Username 就 Fillable」逻辑——bitwarden 不在
-        //    弹窗决策层做「无密码框时过滤低精度账号」的二次保险，而是靠前置的字段识别
-        //    阶段把搜索框等判为 Unused。Monica 的 TYPE_TEXT_VARIATION_NORMAL fallback
-        //    比 bitwarden 宽松（会把纯 text 判为 USERNAME:LOWEST），但电影猎手等真登录
-        //    场景的确定 bug优先于假设性的搜索框误弹（后者可用黑名单兜底）。
+        // 弱目标模式分为两种：
+        // - 手动请求：维持原有宽松行为，允许用户主动选择任意弱字段。
+        // - 自动兼容重解析：密码术语可以提升密码字段；孤立的弱账号字段只有在自身携带
+        //   明确 login/account/账号等术语时才提升到 MEDIUM。普通数量、金额和搜索字段
+        //   不会因为首轮无结果而获得与手动请求相同的放行权限。
         val effectiveItems = if (allowWeakTargets) {
             promotePasswordTermCandidates(confidenceFilteredItems)
         } else {
             confidenceFilteredItems
+        }
+        val promotedPasswordCount = effectiveItems.zip(confidenceFilteredItems).count { (after, before) ->
+            (after.hint == InternalHint.PASSWORD || after.hint == InternalHint.NEW_PASSWORD) &&
+                after.hint != before.hint
         }
         val hasPasswordInItems = effectiveItems.any {
             it.hint == InternalHint.PASSWORD || it.hint == InternalHint.NEW_PASSWORD
@@ -610,10 +606,31 @@ class EnhancedAutofillStructureParserV2 {
                 it.hint == InternalHint.EMAIL_ADDRESS ||
                 it.hint == InternalHint.PHONE_NUMBER
         }
-        val weakLoginContext = allowWeakTargets && !hasPasswordInItems && hasLoginTypeField
+        val automaticWeakReparse = allowWeakTargets && requireExplicitWeakLoginSignal
+        val weakLoginContext = automaticWeakReparse && !hasPasswordInItems && effectiveItems.any {
+            (it.hint == InternalHint.USERNAME ||
+                it.hint == InternalHint.EMAIL_ADDRESS ||
+                it.hint == InternalHint.PHONE_NUMBER) &&
+                it.hasLoginTerm
+        }
         val loginFilteredItems = when {
             hasPasswordInItems -> effectiveItems
-            weakLoginContext -> effectiveItems
+            allowWeakTargets && !automaticWeakReparse -> effectiveItems
+            automaticWeakReparse -> effectiveItems.mapNotNull { item ->
+                val accountLike = item.hint == InternalHint.USERNAME ||
+                    item.hint == InternalHint.EMAIL_ADDRESS ||
+                    item.hint == InternalHint.PHONE_NUMBER
+                if (!accountLike) {
+                    item
+                } else {
+                    AutofillDetectionPolicy.automaticWeakAccountAccuracy(
+                        accuracy = item.accuracy,
+                        hasLoginTerm = item.hasLoginTerm,
+                    )?.let { admittedAccuracy ->
+                        item.copy(accuracy = admittedAccuracy)
+                    }
+                }
+            }
             else -> effectiveItems.filterNot {
                 (it.hint == InternalHint.USERNAME ||
                     it.hint == InternalHint.EMAIL_ADDRESS ||
@@ -632,7 +649,8 @@ class EnhancedAutofillStructureParserV2 {
                 "loginFilteredCount" to loginFilteredItems.size,
                 "candidates" to candidateItems.joinToString { "${it.hint}:${it.accuracy.name}" },
                 "allowWeakTargets" to allowWeakTargets,
-                "promotedPasswordCount" to (effectiveItems.size - confidenceFilteredItems.size).coerceAtLeast(0),
+                "requireExplicitWeakLoginSignal" to requireExplicitWeakLoginSignal,
+                "promotedPasswordCount" to promotedPasswordCount,
                 "hasPasswordInItems" to hasPasswordInItems,
                 "hasLoginTypeField" to hasLoginTypeField,
                 "weakLoginContext" to weakLoginContext,
@@ -641,15 +659,23 @@ class EnhancedAutofillStructureParserV2 {
         loginFilteredItems
             .groupBy { it.id }
             .forEach { groupedById ->
-                val groupHints = groupedById.value.joinToString { "${it.hint}:${it.accuracy.name}" }
                 val forceAutofillOff = groupedById.value.any {
                     it.hint == InternalHint.OFF && it.accuracy == Accuracy.HIGHEST
                 }
+                val isAlwaysExcluded = groupedById.value.any {
+                    it.hint == InternalHint.OFF && it.reason == "url-bar"
+                }
+                if (AutofillDetectionPolicy.shouldSkipAutofillOffGroup(
+                        respectAutofillOff = respectAutofillOff,
+                        hasForcedOffSignal = forceAutofillOff,
+                        isAlwaysExcluded = isAlwaysExcluded,
+                    )
+                ) {
+                    return@forEach
+                }
                 var structureItems = if (forceAutofillOff) {
-                    // importantForAutofill=NO 的节点（OFF:HIGHEST）应跳过，
-                    // 但若同 id 组有来自其它信号（autofillHints/html）的非 OFF 候选
-                    // （如 EMAIL/PHONE/PASSWORD），应保留这些非 OFF 候选而非整组跳过。
-                    // 否则电影猎手等 App 的重要ForAutofill=NO 节点会连带丢弃同组的有效字段。
+                    // 用户关闭“遵循 autofill-off”后，允许同组的明确字段信号覆盖
+                    // importantForAutofill=NO；URL 栏仍由 isAlwaysExcluded 永久排除。
                     val nonOff = groupedById.value.filter { it.hint != InternalHint.OFF }
                     if (nonOff.isNotEmpty()) nonOff else return@forEach
                 } else if (respectAutofillOff) {
@@ -922,8 +948,10 @@ class EnhancedAutofillStructureParserV2 {
                             "hasPasswordTerm" to nodeHasPasswordTerm,
                             "hasLoginTerm" to nodeHasLoginTerm,
                             "htmlTag" to (node.htmlInfo?.tag ?: "none"),
-                            "htmlAttrs" to (node.htmlInfo?.attributes
-                                ?.joinToString(",") { "${it.first}=${it.second}" } ?: "none"),
+                            "htmlAttrNames" to (node.htmlInfo?.attributes
+                                ?.map { it.first }
+                                ?.distinct()
+                                ?.joinToString(",") ?: "none"),
                             "isVisible" to (node.visibility == View.VISIBLE),
                             "isFocused" to node.isFocused,
                         ),
@@ -1451,6 +1479,7 @@ class EnhancedAutofillStructureParserV2 {
                 out += ParsedItemBuilder(
                     accuracy = Accuracy.HIGHEST,
                     hint = InternalHint.OFF,
+                    reason = "url-bar",
                 )
                 return out
             }
@@ -1465,6 +1494,7 @@ class EnhancedAutofillStructureParserV2 {
             out += ParsedItemBuilder(
                 accuracy = Accuracy.HIGHEST,
                 hint = InternalHint.OFF,
+                reason = "important-for-autofill-no",
             )
             return out
         }

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/MonicaAutofillServiceNg.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/MonicaAutofillServiceNg.kt
@@ -17,7 +17,6 @@ import android.service.autofill.SaveRequest
 import android.view.View
 import android.view.autofill.AutofillId
 import android.text.InputType
-import android.util.Log
 import android.view.inputmethod.InlineSuggestionsRequest
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CoroutineScope
@@ -274,6 +273,7 @@ class MonicaAutofillServiceNg : AutofillService() {
                     structure = structure,
                     respectAutofillOff = respectAutofillOff,
                     allowWeakTargets = true,
+                    requireExplicitWeakLoginSignal = true,
                 )
                 AutofillLogger.d(
                     "AF",
@@ -320,7 +320,7 @@ class MonicaAutofillServiceNg : AutofillService() {
         synchronized(passwordMemoryByPackage) {
             if (currentPasswordItems.isNotEmpty()) {
                 passwordMemoryByPackage[pkgKey] = parsed.items.filter { isLoginHint(it.hint) }
-            } else if (currentHasLoginContext || passwordMemoryByPackage.containsKey(pkgKey)) {
+            } else if (currentHasLoginContext) {
                 val cached = passwordMemoryByPackage[pkgKey]
                 if (cached != null && cached.isNotEmpty() &&
                     cached.all { structureContainsAutofillId(structure, it.id) }
@@ -394,12 +394,11 @@ class MonicaAutofillServiceNg : AutofillService() {
             return null
         }
 
-        // 兼容回退路径（usedWeakReparse）：首轮保守解析零字段、二次弱解析才找回的字段，
-        // 在选择期也放宽账号字段的精度/密码门槛（作用同 manualRequest 的 shouldKeepTarget 宽松分支），
-        // 但非登录类字段仍被 isSupportedFillableHint 挡掉，不会误弹搜索框/昵称。
+        // 自动兼容重解析仍使用自动请求的选择门槛。解析器只会把带明确登录术语的
+        // 弱账号字段提升到 MEDIUM，不能借用手动请求的全放行权限。
         val fillableTargets = selectFillableTargets(
             items = parsed.items,
-            manualRequest = isManualRequest || usedWeakReparse,
+            manualRequest = isManualRequest,
         )
         AutofillLogger.d(
             "AF",
@@ -1361,8 +1360,9 @@ class MonicaAutofillServiceNg : AutofillService() {
                 InputType.TYPE_TEXT_VARIATION_WEB_EMAIL_ADDRESS,
                 -> return FieldHint.EMAIL_ADDRESS
 
-                InputType.TYPE_TEXT_VARIATION_PHONETIC -> return FieldHint.PHONE_NUMBER
             }
+        } else if (classBits == InputType.TYPE_CLASS_PHONE) {
+            return FieldHint.PHONE_NUMBER
         } else if (classBits == InputType.TYPE_CLASS_NUMBER) {
             if ((inputType and InputType.TYPE_MASK_VARIATION) ==
                 InputType.TYPE_NUMBER_VARIATION_PASSWORD

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/MonicaAutofillServiceNg.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/MonicaAutofillServiceNg.kt
@@ -267,10 +267,10 @@ class MonicaAutofillServiceNg : AutofillService() {
                 usedWeakReparse = true
             }
         }
-        // 兼容回退（Bitwarden 式）：仅当首轮已识别到账号类字段、但未识别到密码字段时，
-        // 才把当前聚焦的字段纳入可填充目标。用于补全被漏识别的密码框（如影视类 App 使用
-        // VISIBLE_PASSWORD 变体的密码框），让聚焦密码框时也能弹面板并正确回填账号与密码。
-        // 普通输入框（搜索框/备注/昵称等）的聚焦不会触发此逻辑，避免误弹密码建议。
+        // 兼容回退（Bitwarden 式）：仅当屏幕已进入登录上下文（已识别到账号类字段
+        // 或密码字段）时，才把当前聚焦的字段纳入可填充目标，用于补全被漏识别的
+        // 登录字段（如影视类 App 的账号框/使用 VISIBLE_PASSWORD 变体的密码框）。
+        // 非登录屏幕（搜索框/备注/昵称等，且无密码框）不会触发此逻辑，避免误弹密码建议。
         val hasAccountTarget = parsed.items.any {
             it.hint == FieldHint.USERNAME ||
                 it.hint == FieldHint.EMAIL_ADDRESS ||
@@ -279,8 +279,8 @@ class MonicaAutofillServiceNg : AutofillService() {
         val hasPasswordTarget = parsed.items.any {
             it.hint == FieldHint.PASSWORD || it.hint == FieldHint.NEW_PASSWORD
         }
-        val focusedSyntheticItems = if (hasAccountTarget && !hasPasswordTarget) {
-            buildFocusedSyntheticItems(structure, parsed.items)
+        val focusedSyntheticItems = if (hasAccountTarget || hasPasswordTarget) {
+            buildFocusedSyntheticItems(structure, parsed.items, hasPasswordTarget)
         } else {
             emptyList()
         }
@@ -1218,6 +1218,7 @@ class MonicaAutofillServiceNg : AutofillService() {
     private fun buildFocusedSyntheticItems(
         structure: AssistStructure,
         existingItems: List<EnhancedAutofillStructureParserV2.ParsedItem>,
+        hasPasswordTarget: Boolean,
     ): List<EnhancedAutofillStructureParserV2.ParsedItem> {
         val existingIds = existingItems.map { it.id }.toSet()
         val out = mutableListOf<EnhancedAutofillStructureParserV2.ParsedItem>()
@@ -1225,6 +1226,7 @@ class MonicaAutofillServiceNg : AutofillService() {
             collectFocusedSyntheticItems(
                 node = structure.getWindowNodeAt(index).rootViewNode,
                 existingIds = existingIds,
+                hasPasswordTarget = hasPasswordTarget,
                 out = out,
             )
         }
@@ -1234,13 +1236,14 @@ class MonicaAutofillServiceNg : AutofillService() {
     private fun collectFocusedSyntheticItems(
         node: AssistStructure.ViewNode,
         existingIds: Set<AutofillId>,
+        hasPasswordTarget: Boolean,
         out: MutableList<EnhancedAutofillStructureParserV2.ParsedItem>,
     ) {
         if (node.isFocused &&
             node.autofillId != null &&
             !existingIds.contains(node.autofillId)
         ) {
-            val inferredHint = inferFocusedFieldHint(node)
+            val inferredHint = inferFocusedFieldHint(node, hasPasswordTarget)
             if (inferredHint != null) {
                 out += EnhancedAutofillStructureParserV2.ParsedItem(
                     id = node.autofillId!!,
@@ -1254,12 +1257,20 @@ class MonicaAutofillServiceNg : AutofillService() {
         }
         for (childIndex in 0 until node.childCount) {
             node.getChildAt(childIndex)?.let {
-                collectFocusedSyntheticItems(node = it, existingIds = existingIds, out = out)
+                collectFocusedSyntheticItems(
+                    node = it,
+                    existingIds = existingIds,
+                    hasPasswordTarget = hasPasswordTarget,
+                    out = out,
+                )
             }
         }
     }
 
-    private fun inferFocusedFieldHint(node: AssistStructure.ViewNode): FieldHint? {
+    private fun inferFocusedFieldHint(
+        node: AssistStructure.ViewNode,
+        hasPasswordTarget: Boolean,
+    ): FieldHint? {
         val inputType = node.inputType
         val classBits = inputType and InputType.TYPE_MASK_CLASS
         if (classBits == InputType.TYPE_CLASS_TEXT) {
@@ -1282,9 +1293,10 @@ class MonicaAutofillServiceNg : AutofillService() {
                 return FieldHint.PASSWORD
             }
         }
-        // 非密码/邮箱/电话类的聚焦文本框（搜索框、备注、昵称等）不合成账号条目，
-        // 避免普通输入框误弹密码建议。
-        return null
+        // 非密码/邮箱/电话类的聚焦文本框：仅当屏幕上已存在密码框（登录上下文）时，
+        // 才当作账号字段合成，用于补全漏识别的账号框（如影视类 App）。
+        // 无密码上下文的普通文本框（搜索框/备注/昵称等）不合成，避免误弹密码建议。
+        return if (hasPasswordTarget) FieldHint.USERNAME else null
     }
 
     override fun onConnected() {

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/MonicaAutofillServiceNg.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/MonicaAutofillServiceNg.kt
@@ -270,10 +270,14 @@ class MonicaAutofillServiceNg : AutofillService() {
                 )
             )
             if (firstPassTargets.isEmpty()) {
+                val knownLoginPackage = synchronized(passwordMemoryByPackage) {
+                    passwordMemoryByPackage.containsKey(fallbackPackage)
+                }
                 val weakParsed = parser.parse(
                     structure = structure,
                     respectAutofillOff = respectAutofillOff,
                     allowWeakTargets = true,
+                    knownLoginPackage = knownLoginPackage,
                 )
                 AutofillLogger.d(
                     "AF",
@@ -282,6 +286,7 @@ class MonicaAutofillServiceNg : AutofillService() {
                         "requestId" to requestId,
                         "firstPassItemCount" to parsed.items.size,
                         "weakItemCount" to weakParsed.items.size,
+                        "knownLoginPackage" to knownLoginPackage,
                     )
                 )
                 parsed = weakParsed

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/MonicaAutofillServiceNg.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/MonicaAutofillServiceNg.kt
@@ -67,6 +67,15 @@ class MonicaAutofillServiceNg : AutofillService() {
         private val fillRequestSequence = AtomicLong(0L)
     }
 
+    /**
+     * 跨请求登录字段记忆：缓存各包最近一次识别到的登录字段列表（账号 + 密码）。
+     * 用于应对电影猎手等 App 的密码框在部分 FillRequest 中因布局/动画时序而不可见、
+     * 被解析器丢弃，连带账号也被低精度过滤清掉，导致登录目标「时有时无」。
+     * 仅当缓存的所有登录字段 AutofillId 仍存在于当前 AssistStructure 时才整体回补，
+     * 避免注入失效 id。
+     */
+    private val passwordMemoryByPackage = mutableMapOf<String, List<ParsedItem>>()
+
     private data class RecentFillSuggestions(
         val key: String,
         val createdAtMs: Long,
@@ -249,12 +258,16 @@ class MonicaAutofillServiceNg : AutofillService() {
         var usedWeakReparse = false
         if (!isManualRequest) {
             val firstPassTargets = selectFillableTargets(parsed.items, isManualRequest)
-            Log.d(
-                "MonicaAutofill",
-                "DIAG firstPassTargets=${firstPassTargets.size} " +
-                    "hints=[${firstPassTargets.joinToString { it.hint.name }}] " +
-                    "parsedItems=${parsed.items.size} " +
-                    "parsedHints=[${parsed.items.joinToString { "${it.hint}:${it.accuracy.name}" }}]"
+            AutofillLogger.d(
+                "AF",
+                "DIAG firstPassTargets",
+                metadata = mapOf(
+                    "requestId" to requestId,
+                    "firstPassTargets" to firstPassTargets.size,
+                    "hints" to firstPassTargets.joinToString { it.hint.name },
+                    "parsedItems" to parsed.items.size,
+                    "parsedHints" to parsed.items.joinToString { "${it.hint}:${it.accuracy.name}" },
+                )
             )
             if (firstPassTargets.isEmpty()) {
                 val weakParsed = parser.parse(
@@ -294,6 +307,50 @@ class MonicaAutofillServiceNg : AutofillService() {
         }
         if (focusedSyntheticItems.isNotEmpty()) {
             parsed = parsed.copy(items = parsed.items + focusedSyntheticItems)
+        }
+        // 跨请求登录字段记忆与回补：电影猎手等 App 的密码框在部分 FillRequest 中因
+        // 布局/动画时序而不可见、被解析器连同账号一起丢弃，导致登录目标「时有时无」。
+        // 识别到登录字段时缓存（账号+密码）；后续同包请求若缺失密码、且缓存的所有登录
+        // 字段 id 仍存在于当前结构（可见或不可见均可）时，整体回补，保证面板稳定出现。
+        val pkgKey = parsed.applicationId ?: fallbackPackage
+        val currentPasswordItems = parsed.items.filter {
+            it.hint == FieldHint.PASSWORD || it.hint == FieldHint.NEW_PASSWORD
+        }
+        val currentHasLoginContext = parsed.items.any { isLoginHint(it.hint) }
+        synchronized(passwordMemoryByPackage) {
+            if (currentPasswordItems.isNotEmpty()) {
+                passwordMemoryByPackage[pkgKey] = parsed.items.filter { isLoginHint(it.hint) }
+            } else if (currentHasLoginContext || passwordMemoryByPackage.containsKey(pkgKey)) {
+                val cached = passwordMemoryByPackage[pkgKey]
+                if (cached != null && cached.isNotEmpty() &&
+                    cached.all { structureContainsAutofillId(structure, it.id) }
+                ) {
+                    val baseIndex = parsed.items.maxOfOrNull { it.traversalIndex } ?: 0
+                    val recovered = cached
+                        .filter { c -> parsed.items.none { it.id == c.id } }
+                        .mapIndexed { index, c ->
+                            c.copy(
+                                isVisible = findNodeVisibility(structure, c.id) ?: c.isVisible,
+                                isFocused = false,
+                                accuracy = EnhancedAutofillStructureParserV2.Accuracy.MEDIUM,
+                                traversalIndex = baseIndex + index + 1,
+                            )
+                        }
+                    if (recovered.isNotEmpty()) {
+                        parsed = parsed.copy(items = parsed.items + recovered)
+                        AutofillLogger.d(
+                            "AF",
+                            "Login targets recovered from memory",
+                            metadata = mapOf(
+                                "requestId" to requestId,
+                                "packageName" to pkgKey,
+                                "recoveredCount" to recovered.size,
+                                "recoveredHints" to recovered.joinToString { it.hint.name },
+                            )
+                        )
+                    }
+                }
+            }
         }
         val packageName = resolveEffectivePackageName(
             parsedApplicationId = parsed.applicationId,
@@ -344,12 +401,17 @@ class MonicaAutofillServiceNg : AutofillService() {
             items = parsed.items,
             manualRequest = isManualRequest || usedWeakReparse,
         )
-        Log.d(
-            "MonicaAutofill",
-            "DIAG fillableTargets=${fillableTargets.size} " +
-                "hints=[${fillableTargets.joinToString { it.hint.name }}] " +
-                "usedWeakReparse=$usedWeakReparse " +
-                "hasLoginTargets=${fillableTargets.any { isLoginHint(it.hint) }}"
+        AutofillLogger.d(
+            "AF",
+            "DIAG fillableTargets",
+            metadata = mapOf(
+                "requestId" to requestId,
+                "fillableTargets" to fillableTargets.size,
+                "hints" to fillableTargets.joinToString { it.hint.name },
+                "usedWeakReparse" to usedWeakReparse,
+                "hasLoginTargets" to fillableTargets.any { isLoginHint(it.hint) },
+                "hasPasswordTarget" to (fillableTargets.any { it.hint == FieldHint.PASSWORD || it.hint == FieldHint.NEW_PASSWORD }),
+            )
         )
         if (fillableTargets.isEmpty()) {
             AutofillLogger.i(
@@ -1314,6 +1376,66 @@ class MonicaAutofillServiceNg : AutofillService() {
         return if (hasPasswordTarget) FieldHint.USERNAME else null
     }
 
+    /**
+     * 判断指定 [AutofillId] 是否存在于当前 [AssistStructure]（可见或不可见均可）。
+     * 用于密码框跨请求携带时校验缓存 id 是否仍有效，避免注入失效 id。
+     */
+    private fun structureContainsAutofillId(
+        structure: AssistStructure,
+        id: AutofillId,
+    ): Boolean {
+        for (i in 0 until structure.windowNodeCount) {
+            if (containsAutofillId(structure.getWindowNodeAt(i).rootViewNode, id)) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private fun containsAutofillId(
+        node: AssistStructure.ViewNode,
+        id: AutofillId,
+    ): Boolean {
+        if (node.autofillId == id) return true
+        for (i in 0 until node.childCount) {
+            node.getChildAt(i)?.let {
+                if (containsAutofillId(it, id)) return true
+            }
+        }
+        return false
+    }
+
+    /**
+     * 查找指定 [AutofillId] 在当前 [AssistStructure] 中的可见性；不存在则返回 null。
+     */
+    private fun findNodeVisibility(
+        structure: AssistStructure,
+        id: AutofillId,
+    ): Boolean? {
+        for (i in 0 until structure.windowNodeCount) {
+            val visibility = findNodeVisibilityInWindow(
+                structure.getWindowNodeAt(i).rootViewNode,
+                id,
+            )
+            if (visibility != null) return visibility
+        }
+        return null
+    }
+
+    private fun findNodeVisibilityInWindow(
+        node: AssistStructure.ViewNode,
+        id: AutofillId,
+    ): Boolean? {
+        if (node.autofillId == id) return node.visibility == View.VISIBLE
+        for (i in 0 until node.childCount) {
+            node.getChildAt(i)?.let {
+                val visibility = findNodeVisibilityInWindow(it, id)
+                if (visibility != null) return visibility
+            }
+        }
+        return null
+    }
+
     override fun onConnected() {
         super.onConnected()
         AutofillLogger.i("AF", "Service connected")
@@ -1321,6 +1443,7 @@ class MonicaAutofillServiceNg : AutofillService() {
 
     override fun onDisconnected() {
         AutofillSessionGrants.clear()
+        passwordMemoryByPackage.clear()
         super.onDisconnected()
         AutofillLogger.i("AF", "Service disconnected")
     }

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/MonicaAutofillServiceNg.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/MonicaAutofillServiceNg.kt
@@ -287,9 +287,6 @@ class MonicaAutofillServiceNg : AutofillService() {
                 parsed = weakParsed
                 usedWeakReparse = true
             }
-                parsed = weakParsed
-                usedWeakReparse = true
-            }
         }
         // 兼容回退（Bitwarden 式）：仅当屏幕已进入登录上下文（已识别到账号类字段
         // 或密码字段）时，才把当前聚焦的字段纳入可填充目标，用于补全被漏识别的

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/MonicaAutofillServiceNg.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/MonicaAutofillServiceNg.kt
@@ -267,12 +267,23 @@ class MonicaAutofillServiceNg : AutofillService() {
                 usedWeakReparse = true
             }
         }
-        // 兼容回退（Bitwarden 式）：把当前聚焦的字段也纳入可填充目标。
-        // 部分小众/自定义登录框（如影视类 App）的密码框未被解析识别，
-        // 仅识别到账号字段，导致聚焦密码框时框架找不到可填充目标而不弹面板。
-        // 这里直接依据聚焦节点的 inputType 推断 hint（密码框→PASSWORD），
-        // 保证聚焦字段上也能显示填充提示，并让选择器正确回填账号与密码。
-        val focusedSyntheticItems = buildFocusedSyntheticItems(structure, parsed.items)
+        // 兼容回退（Bitwarden 式）：仅当首轮已识别到账号类字段、但未识别到密码字段时，
+        // 才把当前聚焦的字段纳入可填充目标。用于补全被漏识别的密码框（如影视类 App 使用
+        // VISIBLE_PASSWORD 变体的密码框），让聚焦密码框时也能弹面板并正确回填账号与密码。
+        // 普通输入框（搜索框/备注/昵称等）的聚焦不会触发此逻辑，避免误弹密码建议。
+        val hasAccountTarget = parsed.items.any {
+            it.hint == FieldHint.USERNAME ||
+                it.hint == FieldHint.EMAIL_ADDRESS ||
+                it.hint == FieldHint.PHONE_NUMBER
+        }
+        val hasPasswordTarget = parsed.items.any {
+            it.hint == FieldHint.PASSWORD || it.hint == FieldHint.NEW_PASSWORD
+        }
+        val focusedSyntheticItems = if (hasAccountTarget && !hasPasswordTarget) {
+            buildFocusedSyntheticItems(structure, parsed.items)
+        } else {
+            emptyList()
+        }
         if (focusedSyntheticItems.isNotEmpty()) {
             parsed = parsed.copy(items = parsed.items + focusedSyntheticItems)
         }
@@ -1271,8 +1282,9 @@ class MonicaAutofillServiceNg : AutofillService() {
                 return FieldHint.PASSWORD
             }
         }
-        // 默认当作账号字段，确保至少能把填充提示锚定到聚焦框
-        return FieldHint.USERNAME
+        // 非密码/邮箱/电话类的聚焦文本框（搜索框、备注、昵称等）不合成账号条目，
+        // 避免普通输入框误弹密码建议。
+        return null
     }
 
     override fun onConnected() {

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/MonicaAutofillServiceNg.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/MonicaAutofillServiceNg.kt
@@ -17,6 +17,7 @@ import android.service.autofill.SaveRequest
 import android.view.View
 import android.view.autofill.AutofillId
 import android.text.InputType
+import android.util.Log
 import android.view.inputmethod.InlineSuggestionsRequest
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CoroutineScope

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/MonicaAutofillServiceNg.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/MonicaAutofillServiceNg.kt
@@ -248,6 +248,13 @@ class MonicaAutofillServiceNg : AutofillService() {
         var usedWeakReparse = false
         if (!isManualRequest) {
             val firstPassTargets = selectFillableTargets(parsed.items, isManualRequest)
+            Log.d(
+                "MonicaAutofill",
+                "DIAG firstPassTargets=${firstPassTargets.size} " +
+                    "hints=[${firstPassTargets.joinToString { it.hint.name }}] " +
+                    "parsedItems=${parsed.items.size} " +
+                    "parsedHints=[${parsed.items.joinToString { "${it.hint}:${it.accuracy.name}" }}]"
+            )
             if (firstPassTargets.isEmpty()) {
                 val weakParsed = parser.parse(
                     structure = structure,
@@ -335,6 +342,13 @@ class MonicaAutofillServiceNg : AutofillService() {
         val fillableTargets = selectFillableTargets(
             items = parsed.items,
             manualRequest = isManualRequest || usedWeakReparse,
+        )
+        Log.d(
+            "MonicaAutofill",
+            "DIAG fillableTargets=${fillableTargets.size} " +
+                "hints=[${fillableTargets.joinToString { it.hint.name }}] " +
+                "usedWeakReparse=$usedWeakReparse " +
+                "hasLoginTargets=${fillableTargets.any { isLoginHint(it.hint) }}"
         )
         if (fillableTargets.isEmpty()) {
             AutofillLogger.i(

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/MonicaAutofillServiceNg.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/MonicaAutofillServiceNg.kt
@@ -270,14 +270,10 @@ class MonicaAutofillServiceNg : AutofillService() {
                 )
             )
             if (firstPassTargets.isEmpty()) {
-                val knownLoginPackage = synchronized(passwordMemoryByPackage) {
-                    passwordMemoryByPackage.containsKey(fallbackPackage)
-                }
                 val weakParsed = parser.parse(
                     structure = structure,
                     respectAutofillOff = respectAutofillOff,
                     allowWeakTargets = true,
-                    knownLoginPackage = knownLoginPackage,
                 )
                 AutofillLogger.d(
                     "AF",
@@ -286,9 +282,11 @@ class MonicaAutofillServiceNg : AutofillService() {
                         "requestId" to requestId,
                         "firstPassItemCount" to parsed.items.size,
                         "weakItemCount" to weakParsed.items.size,
-                        "knownLoginPackage" to knownLoginPackage,
                     )
                 )
+                parsed = weakParsed
+                usedWeakReparse = true
+            }
                 parsed = weakParsed
                 usedWeakReparse = true
             }

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/MonicaAutofillServiceNg.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/MonicaAutofillServiceNg.kt
@@ -16,6 +16,7 @@ import android.service.autofill.SaveCallback
 import android.service.autofill.SaveRequest
 import android.view.View
 import android.view.autofill.AutofillId
+import android.text.InputType
 import android.view.inputmethod.InlineSuggestionsRequest
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CoroutineScope
@@ -235,11 +236,46 @@ class MonicaAutofillServiceNg : AutofillService() {
 
         val respectAutofillOff = autofillPreferences.isV2RespectAutofillOffEnabled.first()
         val isManualRequest = request.flags and FillRequest.FLAG_MANUAL_REQUEST != 0
-        val parsed = parser.parse(
+        var parsed = parser.parse(
             structure = structure,
             respectAutofillOff = respectAutofillOff,
             allowWeakTargets = isManualRequest,
         )
+        // 兼容回退（Bitwarden 式）：部分 App（如影视类自定义登录框）的登录字段没有标准
+        // autofill hint，首轮保守解析会丢弃全部字段导致不弹面板。此时二次解析开启弱目标，
+        // 再由 selectFillableTargets / shouldKeepTarget / isSupportedFillableHint 过滤掉
+        // 搜索框、昵称等非登录误报。仅自动模式触发，手动模式本就开启弱目标。
+        var usedWeakReparse = false
+        if (!isManualRequest) {
+            val firstPassTargets = selectFillableTargets(parsed.items, isManualRequest)
+            if (firstPassTargets.isEmpty()) {
+                val weakParsed = parser.parse(
+                    structure = structure,
+                    respectAutofillOff = respectAutofillOff,
+                    allowWeakTargets = true,
+                )
+                AutofillLogger.d(
+                    "AF",
+                    "Weak-target compatibility reparse triggered",
+                    metadata = mapOf(
+                        "requestId" to requestId,
+                        "firstPassItemCount" to parsed.items.size,
+                        "weakItemCount" to weakParsed.items.size,
+                    )
+                )
+                parsed = weakParsed
+                usedWeakReparse = true
+            }
+        }
+        // 兼容回退（Bitwarden 式）：把当前聚焦的字段也纳入可填充目标。
+        // 部分小众/自定义登录框（如影视类 App）的密码框未被解析识别，
+        // 仅识别到账号字段，导致聚焦密码框时框架找不到可填充目标而不弹面板。
+        // 这里直接依据聚焦节点的 inputType 推断 hint（密码框→PASSWORD），
+        // 保证聚焦字段上也能显示填充提示，并让选择器正确回填账号与密码。
+        val focusedSyntheticItems = buildFocusedSyntheticItems(structure, parsed.items)
+        if (focusedSyntheticItems.isNotEmpty()) {
+            parsed = parsed.copy(items = parsed.items + focusedSyntheticItems)
+        }
         val packageName = resolveEffectivePackageName(
             parsedApplicationId = parsed.applicationId,
             fallbackPackage = fallbackPackage,
@@ -282,9 +318,12 @@ class MonicaAutofillServiceNg : AutofillService() {
             return null
         }
 
+        // 兼容回退路径（usedWeakReparse）：首轮保守解析零字段、二次弱解析才找回的字段，
+        // 在选择期也放宽账号字段的精度/密码门槛（作用同 manualRequest 的 shouldKeepTarget 宽松分支），
+        // 但非登录类字段仍被 isSupportedFillableHint 挡掉，不会误弹搜索框/昵称。
         val fillableTargets = selectFillableTargets(
             items = parsed.items,
-            manualRequest = isManualRequest,
+            manualRequest = isManualRequest || usedWeakReparse,
         )
         if (fillableTargets.isEmpty()) {
             AutofillLogger.i(
@@ -1159,6 +1198,81 @@ class MonicaAutofillServiceNg : AutofillService() {
             }
         }
         return null
+    }
+
+    /**
+     * 收集当前聚焦且未被已解析条目覆盖的可编辑字段，依据其 inputType 推断 hint 后
+     * 合成 ParsedItem，使响应能锚定到用户实际聚焦的框（如密码框），对齐 Bitwarden 行为。
+     */
+    private fun buildFocusedSyntheticItems(
+        structure: AssistStructure,
+        existingItems: List<EnhancedAutofillStructureParserV2.ParsedItem>,
+    ): List<EnhancedAutofillStructureParserV2.ParsedItem> {
+        val existingIds = existingItems.map { it.id }.toSet()
+        val out = mutableListOf<EnhancedAutofillStructureParserV2.ParsedItem>()
+        for (index in 0 until structure.windowNodeCount) {
+            collectFocusedSyntheticItems(
+                node = structure.getWindowNodeAt(index).rootViewNode,
+                existingIds = existingIds,
+                out = out,
+            )
+        }
+        return out
+    }
+
+    private fun collectFocusedSyntheticItems(
+        node: AssistStructure.ViewNode,
+        existingIds: Set<AutofillId>,
+        out: MutableList<EnhancedAutofillStructureParserV2.ParsedItem>,
+    ) {
+        if (node.isFocused &&
+            node.autofillId != null &&
+            !existingIds.contains(node.autofillId)
+        ) {
+            val inferredHint = inferFocusedFieldHint(node)
+            if (inferredHint != null) {
+                out += EnhancedAutofillStructureParserV2.ParsedItem(
+                    id = node.autofillId!!,
+                    hint = inferredHint,
+                    accuracy = EnhancedAutofillStructureParserV2.Accuracy.MEDIUM,
+                    isFocused = true,
+                    isVisible = node.visibility == View.VISIBLE,
+                    traversalIndex = 0,
+                )
+            }
+        }
+        for (childIndex in 0 until node.childCount) {
+            node.getChildAt(childIndex)?.let {
+                collectFocusedSyntheticItems(node = it, existingIds = existingIds, out = out)
+            }
+        }
+    }
+
+    private fun inferFocusedFieldHint(node: AssistStructure.ViewNode): FieldHint? {
+        val inputType = node.inputType
+        val classBits = inputType and InputType.TYPE_MASK_CLASS
+        if (classBits == InputType.TYPE_CLASS_TEXT) {
+            when (inputType and InputType.TYPE_MASK_VARIATION) {
+                InputType.TYPE_TEXT_VARIATION_PASSWORD,
+                InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD,
+                InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD,
+                -> return FieldHint.PASSWORD
+
+                InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS,
+                InputType.TYPE_TEXT_VARIATION_WEB_EMAIL_ADDRESS,
+                -> return FieldHint.EMAIL_ADDRESS
+
+                InputType.TYPE_TEXT_VARIATION_PHONETIC -> return FieldHint.PHONE_NUMBER
+            }
+        } else if (classBits == InputType.TYPE_CLASS_NUMBER) {
+            if ((inputType and InputType.TYPE_MASK_VARIATION) ==
+                InputType.TYPE_NUMBER_VARIATION_PASSWORD
+            ) {
+                return FieldHint.PASSWORD
+            }
+        }
+        // 默认当作账号字段，确保至少能把填充提示锚定到聚焦框
+        return FieldHint.USERNAME
     }
 
     override fun onConnected() {

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/builder/FilledDataBuilderNg.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/builder/FilledDataBuilderNg.kt
@@ -51,7 +51,13 @@ class FilledDataBuilderNg(
         requireAuthentication: Boolean = true,
     ): FilledData {
         val autoLockMinutes = resolveAutoLockTimeoutForAutofill()
-        val isVaultLocked = !securityManager.canAccessVaultNowStrict(context, autoLockMinutes)
+        // 用户设置“永不过期/不锁定”(autoLockMinutes == -1)时，只要密钥材料当前可读即视为已解锁，
+        // 避免自动填充独立进程因会话状态不可见而每次填充都强制二次解锁。
+        val isVaultLocked = if (autoLockMinutes == -1) {
+            !securityManager.canAccessVaultMaterialNow()
+        } else {
+            !securityManager.canAccessVaultNowStrict(context, autoLockMinutes)
+        }
         val maxCipherInlineSuggestionsCount = (request.maxInlineSuggestionsCount - 1)
             .coerceAtMost(MAX_INLINE_SUGGESTION_COUNT)
 

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/builder/FilledDataBuilderNg.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/autofill_ng/builder/FilledDataBuilderNg.kt
@@ -51,13 +51,10 @@ class FilledDataBuilderNg(
         requireAuthentication: Boolean = true,
     ): FilledData {
         val autoLockMinutes = resolveAutoLockTimeoutForAutofill()
-        // 用户设置“永不过期/不锁定”(autoLockMinutes == -1)时，只要密钥材料当前可读即视为已解锁，
-        // 避免自动填充独立进程因会话状态不可见而每次填充都强制二次解锁。
-        val isVaultLocked = if (autoLockMinutes == -1) {
-            !securityManager.canAccessVaultMaterialNow()
-        } else {
-            !securityManager.canAccessVaultNowStrict(context, autoLockMinutes)
-        }
+        // “永不过期”允许会话跨进程生命周期恢复，但显式锁定仍必须立即生效。
+        // 因此始终同时检查会话状态和可用密钥材料，不能仅凭 Keystore 材料可读
+        // 就绕过 SessionManager。
+        val isVaultLocked = !securityManager.canAccessVaultNowStrict(context, autoLockMinutes)
         val maxCipherInlineSuggestionsCount = (request.maxInlineSuggestionsCount - 1)
             .coerceAtMost(MAX_INLINE_SUGGESTION_COUNT)
 

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/security/SessionManager.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/security/SessionManager.kt
@@ -8,86 +8,128 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
+private const val MILLIS_PER_MINUTE = 60_000L
+
 /**
- * 会话管理器 - 统一管理应用解锁状态
+ * Returns the conservative age of a persisted session, or `null` when either
+ * clock moved backwards or the persisted timestamps are incomplete.
  *
- * 职责：
- * - 维护解锁标志、时间戳、进程标识
- * - 暴露 canSkipVerification() 统一判断免验证条件
- * - 负责与 AutoLock 逻辑联动，超时自动清理会话
+ * `elapsedRealtime` detects device reboot while wall time lets the session
+ * survive a normal app-process restart. Using the larger delta fails closed if
+ * the wall clock jumps forward.
+ */
+internal fun persistedSessionAgeMillisOrNull(
+    unlockElapsedRealtime: Long,
+    nowElapsedRealtime: Long,
+    unlockWallTime: Long,
+    nowWallTime: Long,
+): Long? {
+    if (unlockElapsedRealtime <= 0L || unlockWallTime <= 0L) return null
+    val elapsedDelta = nowElapsedRealtime - unlockElapsedRealtime
+    val wallDelta = nowWallTime - unlockWallTime
+    if (elapsedDelta < 0L || wallDelta < 0L) return null
+    return maxOf(elapsedDelta, wallDelta)
+}
+
+internal fun isPersistedSessionWithinTimeout(
+    autoLockMinutes: Int,
+    unlockElapsedRealtime: Long,
+    nowElapsedRealtime: Long,
+    unlockWallTime: Long,
+    nowWallTime: Long,
+): Boolean {
+    val ageMillis = persistedSessionAgeMillisOrNull(
+        unlockElapsedRealtime = unlockElapsedRealtime,
+        nowElapsedRealtime = nowElapsedRealtime,
+        unlockWallTime = unlockWallTime,
+        nowWallTime = nowWallTime,
+    ) ?: return false
+    // Product semantics: "never expire" survives an app-process restart in
+    // the same boot, but a device reboot or invalid clock continuity fails closed.
+    if (autoLockMinutes == -1) return true
+    if (autoLockMinutes <= 0) return false
+    return ageMillis < autoLockMinutes.toLong() * MILLIS_PER_MINUTE
+}
+
+/**
+ * 会话管理器 - 统一管理应用解锁状态。
  *
- * 安全窗规则：
- * - 仅在解锁后 N 分钟内允许免验证
- * - 屏幕锁定时必须重新验证
- * - 进程重启后必须重新验证
- *
- * 跨进程说明（重要）：
- * 自动填充服务（MonicaAutofillServiceNg）运行在独立进程。原实现将解锁状态仅保存在
- * 本对象的内存字段中，导致自动填充进程永远读不到主进程记录的“已解锁”状态，从而在
- * 每次填充时都误判为锁定、强制二次解锁（即使主进程已设置“永不过期/不锁定”）。
- * 现将解锁状态持久化到跨进程可见的 SharedPreferences，使自动填充进程与主进程共享
- * 同一份解锁会话；unlockTimestamp 基于 SystemClock.elapsedRealtime（开机时长，跨进程一致）。
+ * “永不过期”会话允许在同一次开机期间的应用进程重启后恢复，直到用户主动锁定
+ * Monica；设备重启、时钟回拨或时间戳损坏时均按过期处理。
  */
 object SessionManager {
-    
     private const val TAG = "SessionManager"
     private const val PREFS_NAME = "monica_session_state"
     private const val KEY_UNLOCKED = "unlocked"
-    private const val KEY_UNLOCK_TS = "unlock_timestamp"
+    private const val KEY_UNLOCK_ELAPSED_TS = "unlock_timestamp"
+    private const val KEY_UNLOCK_WALL_TS = "unlock_wall_timestamp"
     private const val KEY_AUTO_LOCK = "auto_lock_minutes"
-    
-    // 解锁状态
+
     private val _isUnlocked = MutableStateFlow(false)
     val isUnlocked: StateFlow<Boolean> = _isUnlocked.asStateFlow()
-    
-    // 解锁时间戳（基于 SystemClock.elapsedRealtime，不受系统时间修改影响）
-    private var unlockTimestamp: Long = 0L
-    
-    // 自动锁定超时（分钟），从 SettingsManager 同步；-1 表示永不过期/不锁定
+
+    private var unlockElapsedTimestamp: Long = 0L
+    private var unlockWallTimestamp: Long = 0L
     private var autoLockMinutes: Int = 5
-    
-    // 进程标识（用于检测进程重启）
     private val processId: Int = android.os.Process.myPid()
-    
-    // 跨进程共享：自动填充服务运行在独立进程，需读取主进程写入的解锁状态
+
     private var appContext: Context? = null
     private val prefs: SharedPreferences?
         get() = appContext?.applicationContext
-            ?.getSharedPreferences(PREFS_NAME, Context.MODE_MULTI_PROCESS)
-    
-    /**
-     * 注入应用上下文，用于跨进程持久化解锁状态。
-     * 在 [MonicaApplication.onCreate] 中调用一次即可（各进程独立 Application 实例，
-     * 但应用内部存储在本 UID 下跨进程共享）。
-     */
+            ?.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    /** Inject the application context so the session can survive process restart. */
     fun attachAppContext(context: Context) {
         appContext = context.applicationContext
     }
-    
+
     private fun persistAll() {
-        prefs?.edit()?.apply {
+        val committed = prefs?.edit()?.apply {
             putBoolean(KEY_UNLOCKED, _isUnlocked.value)
-            putLong(KEY_UNLOCK_TS, unlockTimestamp)
+            putLong(KEY_UNLOCK_ELAPSED_TS, unlockElapsedTimestamp)
+            putLong(KEY_UNLOCK_WALL_TS, unlockWallTimestamp)
             putInt(KEY_AUTO_LOCK, autoLockMinutes)
-        }?.apply()
+        }?.commit()
+        if (committed == false) {
+            android.util.Log.w(TAG, "Failed to persist session state")
+        }
     }
-    
-    /**
-     * 标记应用已解锁
-     */
+
+    private fun restorePersistedState() {
+        prefs?.let { stored ->
+            val persistedUnlocked = stored.getBoolean(KEY_UNLOCKED, false)
+            _isUnlocked.value = persistedUnlocked
+            unlockElapsedTimestamp = if (persistedUnlocked) {
+                stored.getLong(KEY_UNLOCK_ELAPSED_TS, 0L)
+            } else {
+                0L
+            }
+            unlockWallTimestamp = if (persistedUnlocked) {
+                stored.getLong(KEY_UNLOCK_WALL_TS, 0L)
+            } else {
+                0L
+            }
+            autoLockMinutes = stored.getInt(KEY_AUTO_LOCK, autoLockMinutes)
+        }
+    }
+
     fun markUnlocked() {
         _isUnlocked.value = true
-        unlockTimestamp = SystemClock.elapsedRealtime()
+        unlockElapsedTimestamp = SystemClock.elapsedRealtime()
+        unlockWallTimestamp = System.currentTimeMillis()
         persistAll()
-        android.util.Log.d(TAG, "Session unlocked at $unlockTimestamp, PID=$processId")
+        android.util.Log.d(
+            TAG,
+            "Session unlocked at elapsed=$unlockElapsedTimestamp, PID=$processId",
+        )
     }
-    
-    /**
-     * 标记应用已锁定
-     */
+
     fun markLocked(clearSecondarySession: Boolean = true) {
         _isUnlocked.value = false
-        unlockTimestamp = 0L
+        unlockElapsedTimestamp = 0L
+        unlockWallTimestamp = 0L
+        // Persist synchronously before clearing in-memory key material so an
+        // immediate process death cannot resurrect an explicitly locked session.
         persistAll()
         SecurityManager.clearRuntimeUnlockCache()
         if (clearSecondarySession) {
@@ -95,99 +137,78 @@ object SessionManager {
         }
         android.util.Log.d(TAG, "Session locked, PID=$processId")
     }
-    
-    /**
-     * 更新自动锁定超时配置。
-     * 注意：仅持久化 autoLockMinutes，不触碰 unlocked/timestamp，避免覆盖其他进程写入的解锁状态。
-     */
+
     fun updateAutoLockTimeout(minutes: Int) {
         autoLockMinutes = minutes
-        prefs?.edit()?.putInt(KEY_AUTO_LOCK, minutes)?.apply()
+        prefs?.edit()?.putInt(KEY_AUTO_LOCK, minutes)?.commit()
         android.util.Log.d(TAG, "Auto-lock timeout updated to $minutes minutes")
     }
-    
-    /**
-     * 检查是否可以跳过验证
-     *
-     * 安全窗规则：
-     * 1. 必须已解锁
-     * 2. 未超过自动锁定时间
-     * 3. 屏幕未锁定
-     *
-     * 跨进程：自动填充进程在此读取主进程持久化的解锁状态，使“已解锁/永不过期”在
-     * 自动填充场景真正生效，避免每次填充强制二次解锁。
-     *
-     * @param context 上下文，用于检查屏幕锁定状态并访问跨进程 SharedPreferences
-     * @return true 如果可以跳过验证
-     */
+
     fun canSkipVerification(context: Context): Boolean {
         appContext = context.applicationContext
-        // 跨进程同步：以持久化的解锁状态为准（自动填充服务独立进程）
-        prefs?.let { p ->
-            val persistedUnlocked = p.getBoolean(KEY_UNLOCKED, false)
-            val persistedTs = p.getLong(KEY_UNLOCK_TS, 0L)
-            val persistedAutoLock = p.getInt(KEY_AUTO_LOCK, autoLockMinutes)
-            _isUnlocked.value = persistedUnlocked
-            if (persistedUnlocked && persistedTs != 0L) {
-                unlockTimestamp = persistedTs
-            } else if (!persistedUnlocked) {
-                unlockTimestamp = 0L
-            }
-            autoLockMinutes = persistedAutoLock
-        }
-        
-        // 检查是否已解锁
+        restorePersistedState()
+
         if (!_isUnlocked.value) {
             android.util.Log.d(TAG, "canSkipVerification: false (not unlocked)")
             return false
         }
-        
-        // 检查是否超时
-        val elapsedMinutes = (SystemClock.elapsedRealtime() - unlockTimestamp) / 60000
-        if (autoLockMinutes != -1 && elapsedMinutes >= autoLockMinutes) {
-            android.util.Log.d(TAG, "canSkipVerification: false (session expired, elapsed=$elapsedMinutes min)")
+
+        val nowElapsed = SystemClock.elapsedRealtime()
+        val nowWall = System.currentTimeMillis()
+        if (!isPersistedSessionWithinTimeout(
+                autoLockMinutes = autoLockMinutes,
+                unlockElapsedRealtime = unlockElapsedTimestamp,
+                nowElapsedRealtime = nowElapsed,
+                unlockWallTime = unlockWallTimestamp,
+                nowWallTime = nowWall,
+            )
+        ) {
+            android.util.Log.d(TAG, "canSkipVerification: false (session expired or clock reset)")
             markLocked(clearSecondarySession = false)
             return false
         }
-        
-        // 检查屏幕是否锁定（仅返回 false，不主动清除会话，避免切后台时误锁）
+
+        // Do not clear the session merely because the screen is temporarily locked.
         val keyguardManager = context.getSystemService(Context.KEYGUARD_SERVICE) as? KeyguardManager
         if (keyguardManager?.isKeyguardLocked == true) {
             android.util.Log.d(TAG, "canSkipVerification: false (device locked)")
             return false
         }
-        
-        android.util.Log.d(TAG, "canSkipVerification: true (unlocked, within timeout, screen unlocked)")
+
+        android.util.Log.d(TAG, "canSkipVerification: true (active session, screen unlocked)")
         return true
     }
-    
-    /**
-     * 刷新会话时间戳（用户活动时调用）
-     */
+
     fun refreshSession() {
         if (_isUnlocked.value) {
-            unlockTimestamp = SystemClock.elapsedRealtime()
+            unlockElapsedTimestamp = SystemClock.elapsedRealtime()
+            unlockWallTimestamp = System.currentTimeMillis()
             persistAll()
-            android.util.Log.d(TAG, "Session refreshed at $unlockTimestamp")
+            android.util.Log.d(TAG, "Session refreshed at elapsed=$unlockElapsedTimestamp")
         }
     }
-    
-    /**
-     * 检查会话是否过期（不自动锁定，仅检查）
-     */
+
     fun isSessionExpired(): Boolean {
         if (!_isUnlocked.value) return true
-        val elapsedMinutes = (SystemClock.elapsedRealtime() - unlockTimestamp) / 60000
-        return autoLockMinutes != -1 && elapsedMinutes >= autoLockMinutes
+        return !isPersistedSessionWithinTimeout(
+            autoLockMinutes = autoLockMinutes,
+            unlockElapsedRealtime = unlockElapsedTimestamp,
+            nowElapsedRealtime = SystemClock.elapsedRealtime(),
+            unlockWallTime = unlockWallTimestamp,
+            nowWallTime = System.currentTimeMillis(),
+        )
     }
-    
-    /**
-     * 获取剩余有效时间（分钟）
-     */
+
     fun getRemainingMinutes(): Int {
         if (!_isUnlocked.value) return 0
         if (autoLockMinutes == -1) return -1
-        val elapsedMinutes = (SystemClock.elapsedRealtime() - unlockTimestamp) / 60000
+        val ageMillis = persistedSessionAgeMillisOrNull(
+            unlockElapsedRealtime = unlockElapsedTimestamp,
+            nowElapsedRealtime = SystemClock.elapsedRealtime(),
+            unlockWallTime = unlockWallTimestamp,
+            nowWallTime = System.currentTimeMillis(),
+        ) ?: return 0
+        val elapsedMinutes = ageMillis / MILLIS_PER_MINUTE
         return maxOf(0, autoLockMinutes - elapsedMinutes.toInt())
     }
 }

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/security/SessionManager.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/security/SessionManager.kt
@@ -2,6 +2,7 @@ package takagi.ru.monica.security
 
 import android.app.KeyguardManager
 import android.content.Context
+import android.content.SharedPreferences
 import android.os.SystemClock
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -9,20 +10,31 @@ import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * 会话管理器 - 统一管理应用解锁状态
- * 
+ *
  * 职责：
- * - 维护内存态解锁标志、时间戳、进程标识
+ * - 维护解锁标志、时间戳、进程标识
  * - 暴露 canSkipVerification() 统一判断免验证条件
  * - 负责与 AutoLock 逻辑联动，超时自动清理会话
- * 
+ *
  * 安全窗规则：
  * - 仅在解锁后 N 分钟内允许免验证
  * - 屏幕锁定时必须重新验证
  * - 进程重启后必须重新验证
+ *
+ * 跨进程说明（重要）：
+ * 自动填充服务（MonicaAutofillServiceNg）运行在独立进程。原实现将解锁状态仅保存在
+ * 本对象的内存字段中，导致自动填充进程永远读不到主进程记录的“已解锁”状态，从而在
+ * 每次填充时都误判为锁定、强制二次解锁（即使主进程已设置“永不过期/不锁定”）。
+ * 现将解锁状态持久化到跨进程可见的 SharedPreferences，使自动填充进程与主进程共享
+ * 同一份解锁会话；unlockTimestamp 基于 SystemClock.elapsedRealtime（开机时长，跨进程一致）。
  */
 object SessionManager {
     
     private const val TAG = "SessionManager"
+    private const val PREFS_NAME = "monica_session_state"
+    private const val KEY_UNLOCKED = "unlocked"
+    private const val KEY_UNLOCK_TS = "unlock_timestamp"
+    private const val KEY_AUTO_LOCK = "auto_lock_minutes"
     
     // 解锁状态
     private val _isUnlocked = MutableStateFlow(false)
@@ -31,11 +43,34 @@ object SessionManager {
     // 解锁时间戳（基于 SystemClock.elapsedRealtime，不受系统时间修改影响）
     private var unlockTimestamp: Long = 0L
     
-    // 自动锁定超时（分钟），从 SettingsManager 同步
+    // 自动锁定超时（分钟），从 SettingsManager 同步；-1 表示永不过期/不锁定
     private var autoLockMinutes: Int = 5
     
     // 进程标识（用于检测进程重启）
     private val processId: Int = android.os.Process.myPid()
+    
+    // 跨进程共享：自动填充服务运行在独立进程，需读取主进程写入的解锁状态
+    private var appContext: Context? = null
+    private val prefs: SharedPreferences?
+        get() = appContext?.applicationContext
+            ?.getSharedPreferences(PREFS_NAME, Context.MODE_MULTI_PROCESS)
+    
+    /**
+     * 注入应用上下文，用于跨进程持久化解锁状态。
+     * 在 [MonicaApplication.onCreate] 中调用一次即可（各进程独立 Application 实例，
+     * 但应用内部存储在本 UID 下跨进程共享）。
+     */
+    fun attachAppContext(context: Context) {
+        appContext = context.applicationContext
+    }
+    
+    private fun persistAll() {
+        prefs?.edit()?.apply {
+            putBoolean(KEY_UNLOCKED, _isUnlocked.value)
+            putLong(KEY_UNLOCK_TS, unlockTimestamp)
+            putInt(KEY_AUTO_LOCK, autoLockMinutes)
+        }?.apply()
+    }
     
     /**
      * 标记应用已解锁
@@ -43,6 +78,7 @@ object SessionManager {
     fun markUnlocked() {
         _isUnlocked.value = true
         unlockTimestamp = SystemClock.elapsedRealtime()
+        persistAll()
         android.util.Log.d(TAG, "Session unlocked at $unlockTimestamp, PID=$processId")
     }
     
@@ -52,6 +88,7 @@ object SessionManager {
     fun markLocked(clearSecondarySession: Boolean = true) {
         _isUnlocked.value = false
         unlockTimestamp = 0L
+        persistAll()
         SecurityManager.clearRuntimeUnlockCache()
         if (clearSecondarySession) {
             SecondarySessionManager.markLocked(clearRuntimeUnlockCache = false)
@@ -60,25 +97,45 @@ object SessionManager {
     }
     
     /**
-     * 更新自动锁定超时配置
+     * 更新自动锁定超时配置。
+     * 注意：仅持久化 autoLockMinutes，不触碰 unlocked/timestamp，避免覆盖其他进程写入的解锁状态。
      */
     fun updateAutoLockTimeout(minutes: Int) {
         autoLockMinutes = minutes
+        prefs?.edit()?.putInt(KEY_AUTO_LOCK, minutes)?.apply()
         android.util.Log.d(TAG, "Auto-lock timeout updated to $minutes minutes")
     }
     
     /**
      * 检查是否可以跳过验证
-     * 
+     *
      * 安全窗规则：
      * 1. 必须已解锁
      * 2. 未超过自动锁定时间
      * 3. 屏幕未锁定
-     * 
-     * @param context 上下文，用于检查屏幕锁定状态
+     *
+     * 跨进程：自动填充进程在此读取主进程持久化的解锁状态，使“已解锁/永不过期”在
+     * 自动填充场景真正生效，避免每次填充强制二次解锁。
+     *
+     * @param context 上下文，用于检查屏幕锁定状态并访问跨进程 SharedPreferences
      * @return true 如果可以跳过验证
      */
     fun canSkipVerification(context: Context): Boolean {
+        appContext = context.applicationContext
+        // 跨进程同步：以持久化的解锁状态为准（自动填充服务独立进程）
+        prefs?.let { p ->
+            val persistedUnlocked = p.getBoolean(KEY_UNLOCKED, false)
+            val persistedTs = p.getLong(KEY_UNLOCK_TS, 0L)
+            val persistedAutoLock = p.getInt(KEY_AUTO_LOCK, autoLockMinutes)
+            _isUnlocked.value = persistedUnlocked
+            if (persistedUnlocked && persistedTs != 0L) {
+                unlockTimestamp = persistedTs
+            } else if (!persistedUnlocked) {
+                unlockTimestamp = 0L
+            }
+            autoLockMinutes = persistedAutoLock
+        }
+        
         // 检查是否已解锁
         if (!_isUnlocked.value) {
             android.util.Log.d(TAG, "canSkipVerification: false (not unlocked)")
@@ -110,6 +167,7 @@ object SessionManager {
     fun refreshSession() {
         if (_isUnlocked.value) {
             unlockTimestamp = SystemClock.elapsedRealtime()
+            persistAll()
             android.util.Log.d(TAG, "Session refreshed at $unlockTimestamp")
         }
     }

--- a/Monica for Android/app/src/test/java/takagi/ru/monica/autofill_ng/AutofillDetectionIntegrationGuardTest.kt
+++ b/Monica for Android/app/src/test/java/takagi/ru/monica/autofill_ng/AutofillDetectionIntegrationGuardTest.kt
@@ -19,6 +19,8 @@ class AutofillDetectionIntegrationGuardTest {
         assertTrue(service.contains("FillRequest.FLAG_MANUAL_REQUEST"))
         assertTrue(service.contains("allowWeakTargets = isManualRequest"))
         assertTrue(service.contains("manualRequest = isManualRequest"))
+        assertFalse(service.contains("manualRequest = isManualRequest || usedWeakReparse"))
+        assertTrue(service.contains("requireExplicitWeakLoginSignal = true"))
         assertTrue(service.contains("if (!isManualRequest && loginTargetCount == 0"))
         assertTrue(parser.contains("if (allowWeakTargets) return@let list"))
         assertTrue(parser.contains("promotePasswordTermCandidates"))
@@ -28,8 +30,46 @@ class AutofillDetectionIntegrationGuardTest {
         assertTrue(parser.contains("hasLoginTypeField"))
         assertTrue(parser.contains("LOWEST username node signals"))
         assertTrue(parser.contains("autofillLabelLoginTranslations"))
+        assertTrue(parser.contains("automaticWeakAccountAccuracy"))
         assertTrue(service.contains("AutofillRequestContextPolicy.allowPackageMatching("))
         assertTrue(service.contains("allowPackageMatch = allowPackageMatch"))
+    }
+
+    @Test
+    fun manualPickerKeepsAccessibilityFillWithClipboardFallback() {
+        val picker = projectFile(
+            "app/src/main/java/takagi/ru/monica/autofill_ng/AutofillPickerActivityV2.kt"
+        ).readText()
+
+        assertTrue(picker.contains("scheduleManualAccessibilityFill"))
+        assertTrue(picker.contains("MonicaAccessibilityService.requestCredentialFill"))
+        assertTrue(picker.contains("copyManualCredentialFallback"))
+        assertFalse(picker.contains("scheduleManualClipboardFill"))
+    }
+
+    @Test
+    fun parserDiagnosticsDoNotPersistHtmlAttributeValues() {
+        val parser = projectFile(
+            "app/src/main/java/takagi/ru/monica/autofill_ng/EnhancedAutofillStructureParserV2.kt"
+        ).readText()
+
+        assertTrue(parser.contains("htmlAttrNames"))
+        assertFalse(parser.contains("\"htmlAttrs\""))
+        assertFalse(
+            parser.contains(
+                """joinToString(",") { "${'$'}{it.first}=${'$'}{it.second}" }"""
+            )
+        )
+    }
+
+    @Test
+    fun neverExpireAutofillStillHonorsExplicitVaultLock() {
+        val builder = projectFile(
+            "app/src/main/java/takagi/ru/monica/autofill_ng/builder/FilledDataBuilderNg.kt"
+        ).readText()
+
+        assertTrue(builder.contains("canAccessVaultNowStrict"))
+        assertFalse(builder.contains("canAccessVaultMaterialNow"))
     }
 
     @Test

--- a/Monica for Android/app/src/test/java/takagi/ru/monica/autofill_ng/AutofillDetectionIntegrationGuardTest.kt
+++ b/Monica for Android/app/src/test/java/takagi/ru/monica/autofill_ng/AutofillDetectionIntegrationGuardTest.kt
@@ -21,8 +21,11 @@ class AutofillDetectionIntegrationGuardTest {
         assertTrue(service.contains("manualRequest = isManualRequest"))
         assertTrue(service.contains("if (!isManualRequest && loginTargetCount == 0"))
         assertTrue(parser.contains("if (allowWeakTargets) return@let list"))
-        assertTrue(parser.contains("allowWeakLoginTargets"))
-        assertTrue(service.contains("knownLoginPackage"))
+        assertTrue(parser.contains("promotePasswordTermCandidates"))
+        assertTrue(parser.contains("nodeHasPasswordTermMatch"))
+        assertTrue(parser.contains("nodeHasLoginTermMatch"))
+        assertTrue(parser.contains("weakLoginContext"))
+        assertTrue(parser.contains("autofillLabelLoginTranslations"))
         assertTrue(service.contains("AutofillRequestContextPolicy.allowPackageMatching("))
         assertTrue(service.contains("allowPackageMatch = allowPackageMatch"))
     }

--- a/Monica for Android/app/src/test/java/takagi/ru/monica/autofill_ng/AutofillDetectionIntegrationGuardTest.kt
+++ b/Monica for Android/app/src/test/java/takagi/ru/monica/autofill_ng/AutofillDetectionIntegrationGuardTest.kt
@@ -21,6 +21,8 @@ class AutofillDetectionIntegrationGuardTest {
         assertTrue(service.contains("manualRequest = isManualRequest"))
         assertTrue(service.contains("if (!isManualRequest && loginTargetCount == 0"))
         assertTrue(parser.contains("if (allowWeakTargets) return@let list"))
+        assertTrue(parser.contains("allowWeakLoginTargets"))
+        assertTrue(service.contains("knownLoginPackage"))
         assertTrue(service.contains("AutofillRequestContextPolicy.allowPackageMatching("))
         assertTrue(service.contains("allowPackageMatch = allowPackageMatch"))
     }

--- a/Monica for Android/app/src/test/java/takagi/ru/monica/autofill_ng/AutofillDetectionIntegrationGuardTest.kt
+++ b/Monica for Android/app/src/test/java/takagi/ru/monica/autofill_ng/AutofillDetectionIntegrationGuardTest.kt
@@ -25,6 +25,8 @@ class AutofillDetectionIntegrationGuardTest {
         assertTrue(parser.contains("nodeHasPasswordTermMatch"))
         assertTrue(parser.contains("nodeHasLoginTermMatch"))
         assertTrue(parser.contains("weakLoginContext"))
+        assertTrue(parser.contains("hasLoginTypeField"))
+        assertTrue(parser.contains("LOWEST username node signals"))
         assertTrue(parser.contains("autofillLabelLoginTranslations"))
         assertTrue(service.contains("AutofillRequestContextPolicy.allowPackageMatching("))
         assertTrue(service.contains("allowPackageMatch = allowPackageMatch"))

--- a/Monica for Android/app/src/test/java/takagi/ru/monica/autofill_ng/AutofillDetectionPolicyTest.kt
+++ b/Monica for Android/app/src/test/java/takagi/ru/monica/autofill_ng/AutofillDetectionPolicyTest.kt
@@ -2,6 +2,7 @@ package takagi.ru.monica.autofill_ng
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import takagi.ru.monica.autofill_ng.EnhancedAutofillStructureParserV2.Accuracy
@@ -18,6 +19,30 @@ class AutofillDetectionPolicyTest {
                 accuracy = Accuracy.LOW,
                 hasPasswordTarget = false,
                 manualRequest = false,
+            )
+        )
+        assertNull(
+            AutofillDetectionPolicy.automaticWeakAccountAccuracy(
+                accuracy = Accuracy.LOW,
+                hasLoginTerm = false,
+            )
+        )
+    }
+
+    @Test
+    fun automaticWeakReparseOnlyPromotesExplicitLoginFields() {
+        assertEquals(
+            Accuracy.MEDIUM,
+            AutofillDetectionPolicy.automaticWeakAccountAccuracy(
+                accuracy = Accuracy.LOWEST,
+                hasLoginTerm = true,
+            )
+        )
+        assertEquals(
+            Accuracy.MEDIUM,
+            AutofillDetectionPolicy.automaticWeakAccountAccuracy(
+                accuracy = Accuracy.MEDIUM,
+                hasLoginTerm = false,
             )
         )
     }
@@ -66,6 +91,37 @@ class AutofillDetectionPolicyTest {
             AutofillDetectionPolicy.shouldIncludeHiddenCredential(
                 hint = FieldHint.PASSWORD,
                 accuracy = Accuracy.HIGH,
+            )
+        )
+        assertTrue(
+            AutofillDetectionPolicy.shouldIncludeHiddenCredential(
+                hint = FieldHint.PASSWORD,
+                accuracy = Accuracy.LOW,
+            )
+        )
+    }
+
+    @Test
+    fun autofillOffPreferenceControlsImportantForAutofillButNeverUrlBars() {
+        assertTrue(
+            AutofillDetectionPolicy.shouldSkipAutofillOffGroup(
+                respectAutofillOff = true,
+                hasForcedOffSignal = true,
+                isAlwaysExcluded = false,
+            )
+        )
+        assertFalse(
+            AutofillDetectionPolicy.shouldSkipAutofillOffGroup(
+                respectAutofillOff = false,
+                hasForcedOffSignal = true,
+                isAlwaysExcluded = false,
+            )
+        )
+        assertTrue(
+            AutofillDetectionPolicy.shouldSkipAutofillOffGroup(
+                respectAutofillOff = false,
+                hasForcedOffSignal = true,
+                isAlwaysExcluded = true,
             )
         )
     }

--- a/Monica for Android/app/src/test/java/takagi/ru/monica/autofill_ng/BitwardenLikeAutofillMatcherNgTest.kt
+++ b/Monica for Android/app/src/test/java/takagi/ru/monica/autofill_ng/BitwardenLikeAutofillMatcherNgTest.kt
@@ -184,6 +184,29 @@ class BitwardenLikeAutofillMatcherNgTest {
         assertEquals(1L, result.first().id)
     }
 
+    @Test
+    fun `strict mode rejects title-only package token matches`() {
+        val entries = listOf(
+            entry(id = 1, title = "GitHub Account"),
+        )
+
+        val strictResult = matcher.match(
+            entries = entries,
+            packageName = "com.github.fake",
+            webDomain = null,
+            config = BitwardenLikeAutofillMatcherNg.Config(strictOnly = true),
+        )
+        val nonStrictResult = matcher.match(
+            entries = entries,
+            packageName = "com.github.fake",
+            webDomain = null,
+            config = BitwardenLikeAutofillMatcherNg.Config(strictOnly = false),
+        )
+
+        assertTrue(strictResult.isEmpty())
+        assertEquals(listOf(1L), nonStrictResult.map { it.id })
+    }
+
     private fun entry(
         id: Long,
         title: String,

--- a/Monica for Android/app/src/test/java/takagi/ru/monica/security/SessionManagerPersistencePolicyTest.kt
+++ b/Monica for Android/app/src/test/java/takagi/ru/monica/security/SessionManagerPersistencePolicyTest.kt
@@ -1,0 +1,78 @@
+package takagi.ru.monica.security
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SessionManagerPersistencePolicyTest {
+
+    @Test
+    fun neverExpireSurvivesAppProcessRestartWithinTheSameBoot() {
+        assertTrue(
+            isPersistedSessionWithinTimeout(
+                autoLockMinutes = -1,
+                unlockElapsedRealtime = 900_000L,
+                nowElapsedRealtime = 910_000L,
+                unlockWallTime = 1_000_000L,
+                nowWallTime = 1_010_000L,
+            )
+        )
+    }
+
+    @Test
+    fun neverExpireFailsClosedAfterDeviceRestart() {
+        assertFalse(
+            isPersistedSessionWithinTimeout(
+                autoLockMinutes = -1,
+                unlockElapsedRealtime = 900_000L,
+                nowElapsedRealtime = 10_000L,
+                unlockWallTime = 1_000_000L,
+                nowWallTime = 2_000_000L,
+            )
+        )
+    }
+
+    @Test
+    fun finiteSessionFailsClosedAfterDeviceRestartOrClockRollback() {
+        assertFalse(
+            isPersistedSessionWithinTimeout(
+                autoLockMinutes = 5,
+                unlockElapsedRealtime = 900_000L,
+                nowElapsedRealtime = 10_000L,
+                unlockWallTime = 1_000_000L,
+                nowWallTime = 1_030_000L,
+            )
+        )
+        assertFalse(
+            isPersistedSessionWithinTimeout(
+                autoLockMinutes = 5,
+                unlockElapsedRealtime = 100_000L,
+                nowElapsedRealtime = 130_000L,
+                unlockWallTime = 2_000_000L,
+                nowWallTime = 1_000_000L,
+            )
+        )
+    }
+
+    @Test
+    fun finiteSessionUsesTheMoreConservativeClockDelta() {
+        assertTrue(
+            isPersistedSessionWithinTimeout(
+                autoLockMinutes = 5,
+                unlockElapsedRealtime = 100_000L,
+                nowElapsedRealtime = 220_000L,
+                unlockWallTime = 1_000_000L,
+                nowWallTime = 1_120_000L,
+            )
+        )
+        assertFalse(
+            isPersistedSessionWithinTimeout(
+                autoLockMinutes = 5,
+                unlockElapsedRealtime = 100_000L,
+                nowElapsedRealtime = 220_000L,
+                unlockWallTime = 1_000_000L,
+                nowWallTime = 1_400_000L,
+            )
+        )
+    }
+}


### PR DESCRIPTION
## 概述

本 PR 修复了 Android Autofill 框架在以下场景的兼容性问题：

### 修复的问题

1. **小众 App 密码填充失效**（如电影猎手 `qingcore677.mingcore8lc.guanglane1dnx`）
   - 弱目标兼容性回退：首轮保守解析无结果时，二次解析开启弱字段放行
   - 对齐 Bitwarden 弹窗门槛：有 Login 类型字段就允许 Fillable，而非要求同时存在密码框
   - `promotePasswordTermCandidates`：从含 password 术语但被误识别的候选里提升出 PASSWORD
   - `forceAutofillOff`：`importantForAutofill=NO` 的节点不再整组跳过同 autofillId 的有效字段
   - 跨请求登录字段记忆与回补
   - 放松隐藏密码框纳入门槛

2. **QQ 搜索框误弹密码条目**
   - 收紧 `TYPE_TEXT_VARIATION_NORMAL` fallback，纯 text 不再无条件产出 `USERNAME:LOWEST`（对齐 Bitwarden 行为）

3. **每次填充强制二次解锁**
   - 解锁会话跨进程共享（`SessionManager`），消除每次填充都需重新验证

### 改动文件

| 文件 | 说明 |
|------|------|
| `EnhancedAutofillStructureParserV2.kt` | 核心 parser：弱重解析、promotePasswordTerm、forceAutofillOff 保留、fallback 收紧 |
| `MonicaAutofillServiceNg.kt` | 服务端：弱重解析触发、登录字段记忆、诊断日志 |
| `AutofillDetectionPolicy.kt` | 策略：`shouldKeepTarget` 微调 |
| `BitwardenLikeAutofillMatcherNg.kt` | 匹配器：对齐 Bitwarden |
| `SessionManager.kt` | 跨进程解锁会话共享 |
| `AutofillPickerActivityV2.kt` | 简化选择器逻辑 |
| `FilledDataBuilderNg.kt` | 数据构建微调 |
| `MonicaApplication.kt` | 初始化适配 |
| `AutofillDetectionIntegrationGuardTest.kt` | 集成守卫测试更新 |

### 参考

所有改动均参考了 Bitwarden Android 客户端的实现策略，确保兼容性同时不降低安全性。