### PR TITLE
feat(bitwarden): 完善Bitwarden自动同步逻辑，缓解多账号同步卡顿

### DIFF
--- a/Monica for Android/app/src/main/java/takagi/ru/monica/MainActivity.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/MainActivity.kt
@@ -924,6 +924,10 @@ fun MonicaContent(
                     popUpTo(Screen.Login.route) { inclusive = true }
                 }
             }
+            launch {
+                delay(1_200L)
+                bitwardenViewModel.requestStartupAutoSync()
+            }
             withContext(Dispatchers.IO) {
                 runCatching {
                     delay(15_000)

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/bitwarden/sync/BitwardenAllVaultAutoSyncScheduler.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/bitwarden/sync/BitwardenAllVaultAutoSyncScheduler.kt
@@ -1,0 +1,70 @@
+package takagi.ru.monica.bitwarden.sync
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+internal class BitwardenAllVaultAutoSyncScheduler(
+    private val scope: CoroutineScope,
+    private val delayBetweenVaultsMs: Long,
+    private val requestSync: (Long) -> Job
+) {
+    private val stateLock = Any()
+    private var nextSessionId = 0L
+    private var activeSessionId: Long? = null
+    private var batchJob: Job? = null
+
+    fun begin(
+        initialDelayMs: Long,
+        vaultIdsProvider: suspend () -> List<Long>
+    ): Long {
+        val sessionId: Long
+        val sessionJob: Job
+        synchronized(stateLock) {
+            batchJob?.cancel()
+            sessionId = ++nextSessionId
+            activeSessionId = sessionId
+            sessionJob = scope.launch(start = CoroutineStart.LAZY) {
+                try {
+                    if (initialDelayMs > 0L) delay(initialDelayMs)
+                    val vaultIds = vaultIdsProvider().distinct()
+                    vaultIds.forEachIndexed { index, vaultId ->
+                        if (index > 0 && delayBetweenVaultsMs > 0L) {
+                            delay(delayBetweenVaultsMs)
+                        }
+                        requestSync(vaultId).join()
+                    }
+                } finally {
+                    synchronized(stateLock) {
+                        if (activeSessionId == sessionId) {
+                            activeSessionId = null
+                            batchJob = null
+                        }
+                    }
+                }
+            }
+            batchJob = sessionJob
+        }
+        sessionJob.start()
+        return sessionId
+    }
+
+    fun end(sessionId: Long) {
+        val jobToCancel = synchronized(stateLock) {
+            if (activeSessionId != sessionId) return
+            activeSessionId = null
+            batchJob.also { batchJob = null }
+        }
+        jobToCancel?.cancel()
+    }
+
+    fun cancelPending() {
+        val jobToCancel = synchronized(stateLock) {
+            activeSessionId = null
+            batchJob.also { batchJob = null }
+        }
+        jobToCancel?.cancel()
+    }
+}

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/bitwarden/sync/BitwardenAutoSyncTargetPlanner.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/bitwarden/sync/BitwardenAutoSyncTargetPlanner.kt
@@ -1,0 +1,29 @@
+package takagi.ru.monica.bitwarden.sync
+
+internal object BitwardenAutoSyncTargetPlanner {
+
+    fun startupTarget(
+        unlockedVaultIds: List<Long>,
+        preferredVaultId: Long?,
+        activeVaultId: Long?
+    ): Long? {
+        val unlocked = unlockedVaultIds.distinct()
+        return preferredVaultId?.takeIf(unlocked::contains)
+            ?: activeVaultId?.takeIf(unlocked::contains)
+            ?: unlocked.firstOrNull()
+    }
+
+    fun allViewTargets(
+        unlockedVaultIds: List<Long>,
+        activeVaultId: Long?
+    ): List<Long> {
+        val unlocked = unlockedVaultIds.distinct()
+        val active = activeVaultId?.takeIf(unlocked::contains) ?: return unlocked
+        return buildList(unlocked.size) {
+            add(active)
+            unlocked.forEach { vaultId ->
+                if (vaultId != active) add(vaultId)
+            }
+        }
+    }
+}

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/bitwarden/sync/BitwardenSyncOrchestrator.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/bitwarden/sync/BitwardenSyncOrchestrator.kt
@@ -98,8 +98,8 @@ class BitwardenSyncOrchestrator(
     private val _statusByVault = MutableStateFlow<Map<Long, VaultSyncStatus>>(emptyMap())
     val statusByVault: StateFlow<Map<Long, VaultSyncStatus>> = _statusByVault.asStateFlow()
 
-    fun requestSync(vaultId: Long, reason: SyncTriggerReason, force: Boolean = false) {
-        scope.launch {
+    fun requestSync(vaultId: Long, reason: SyncTriggerReason, force: Boolean = false): Job {
+        return scope.launch {
             processRequest(vaultId = vaultId, reason = reason, force = force)
         }
     }

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/bitwarden/sync/BitwardenSyncOrchestrator.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/bitwarden/sync/BitwardenSyncOrchestrator.kt
@@ -93,6 +93,7 @@ class BitwardenSyncOrchestrator(
     private val nowProvider: () -> Long = { System.currentTimeMillis() }
 ) {
     private val mutex = Mutex()
+    private val passiveAutoSyncMutex = Mutex()
     private val runtimes = mutableMapOf<Long, VaultRuntime>()
     private val _statusByVault = MutableStateFlow<Map<Long, VaultSyncStatus>>(emptyMap())
     val statusByVault: StateFlow<Map<Long, VaultSyncStatus>> = _statusByVault.asStateFlow()
@@ -241,8 +242,18 @@ class BitwardenSyncOrchestrator(
         if (!runNow) return
 
         val outcome = try {
-            withContext(Dispatchers.IO) {
-                executeSync(vaultId, silent)
+            // Passive auto reasons share one global lock across vaults.
+            // Manual / mutation / forced retries stay free to run immediately.
+            if (!force && isPassiveAutoReason(reason)) {
+                passiveAutoSyncMutex.withLock {
+                    withContext(Dispatchers.IO) {
+                        executeSync(vaultId, silent)
+                    }
+                }
+            } else {
+                withContext(Dispatchers.IO) {
+                    executeSync(vaultId, silent)
+                }
             }
         } catch (error: CancellationException) {
             SyncExecutionOutcome.RetryableError(error.message ?: "同步被取消")
@@ -446,12 +457,15 @@ class BitwardenSyncOrchestrator(
     }
 
     private fun isPassiveAutoReason(reason: SyncTriggerReason): Boolean {
-        return reason == SyncTriggerReason.PAGE_ENTER || reason == SyncTriggerReason.APP_RESUME
+        return reason == SyncTriggerReason.PAGE_ENTER ||
+            reason == SyncTriggerReason.APP_RESUME ||
+            reason == SyncTriggerReason.PERIODIC
     }
 
     private fun passiveAutoQuietWindowMs(reason: SyncTriggerReason): Long {
         return when (reason) {
             SyncTriggerReason.APP_RESUME -> config.appResumeThrottleMs
+            SyncTriggerReason.PERIODIC -> config.appResumeThrottleMs
             else -> config.pageEnterThrottleMs
         }
     }

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/bitwarden/ui/BitwardenAutoSyncEffect.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/bitwarden/ui/BitwardenAutoSyncEffect.kt
@@ -1,0 +1,38 @@
+package takagi.ru.monica.bitwarden.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import kotlinx.coroutines.delay
+import takagi.ru.monica.bitwarden.viewmodel.BitwardenViewModel
+
+private const val PAGE_ENTER_AUTO_SYNC_DELAY_MS = 1_200L
+
+@Composable
+internal fun BitwardenAutoSyncEffect(
+    viewModel: BitwardenViewModel?,
+    selectedVaultId: Long?,
+    isAllView: Boolean,
+    enabled: Boolean = true
+) {
+    DisposableEffect(viewModel, isAllView, enabled) {
+        val allViewSessionId = if (enabled && isAllView) {
+            viewModel?.beginAllViewAutoSync()
+        } else {
+            null
+        }
+        onDispose {
+            if (allViewSessionId != null) {
+                viewModel?.endAllViewAutoSync(allViewSessionId)
+            }
+        }
+    }
+
+    LaunchedEffect(viewModel, selectedVaultId, isAllView, enabled) {
+        val targetViewModel = viewModel ?: return@LaunchedEffect
+        val targetVaultId = selectedVaultId ?: return@LaunchedEffect
+        if (!enabled || isAllView) return@LaunchedEffect
+        delay(PAGE_ENTER_AUTO_SYNC_DELAY_MS)
+        targetViewModel.requestPageEnterAutoSync(targetVaultId)
+    }
+}

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/bitwarden/viewmodel/BitwardenViewModel.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/bitwarden/viewmodel/BitwardenViewModel.kt
@@ -26,6 +26,8 @@ import takagi.ru.monica.bitwarden.cache.BitwardenOfflineSecretCache
 import takagi.ru.monica.bitwarden.repository.BitwardenRepository
 import takagi.ru.monica.bitwarden.service.LoginResult
 import takagi.ru.monica.bitwarden.sync.BitwardenCoordinatedSyncResult
+import takagi.ru.monica.bitwarden.sync.BitwardenAllVaultAutoSyncScheduler
+import takagi.ru.monica.bitwarden.sync.BitwardenAutoSyncTargetPlanner
 import takagi.ru.monica.bitwarden.sync.BitwardenMutationSyncBridge
 import takagi.ru.monica.bitwarden.sync.BitwardenSyncOrchestrator
 import takagi.ru.monica.bitwarden.sync.BitwardenSyncNotificationHelper
@@ -176,6 +178,16 @@ class BitwardenViewModel(application: Application) : AndroidViewModel(applicatio
         isVaultUnlocked = { vaultId -> repository.isVaultUnlocked(vaultId) },
         executeSync = { vaultId, silent -> runSync(vaultId = vaultId, silent = silent) }
     )
+    private val allVaultAutoSyncScheduler = BitwardenAllVaultAutoSyncScheduler(
+        scope = viewModelScope,
+        delayBetweenVaultsMs = MULTI_VAULT_AUTO_SYNC_STAGGER_MS,
+        requestSync = { vaultId ->
+            syncOrchestrator.requestSync(
+                vaultId = vaultId,
+                reason = SyncTriggerReason.PERIODIC
+            )
+        }
+    )
     val syncStatusByVault: StateFlow<Map<Long, VaultSyncStatus>> = combine(
         syncOrchestrator.statusByVault,
         SyncTaskRunner.statuses
@@ -207,6 +219,7 @@ class BitwardenViewModel(application: Application) : AndroidViewModel(applicatio
     }
 
     override fun onCleared() {
+        allVaultAutoSyncScheduler.cancelPending()
         BitwardenMutationSyncBridge.unregister(this)
         super.onCleared()
     }
@@ -250,13 +263,13 @@ class BitwardenViewModel(application: Application) : AndroidViewModel(applicatio
                     )
                 }
 
-                if (triggerStartupAutoSync) {
+                if (triggerStartupAutoSync && active != null && activeUnlockState == UnlockState.Unlocked) {
                     val reason = if (restoredVaultIds.isNotEmpty()) {
                         SyncTriggerReason.APP_RESUME
                     } else {
                         SyncTriggerReason.PAGE_ENTER
                     }
-                    requestAutoSyncForUnlockedVaults(vaultList, reason)
+                    requestAutoSyncWithStartupGrace(active.id, reason)
                 } else if (triggerActiveVaultAutoSync && active != null && activeUnlockState == UnlockState.Unlocked) {
                     val trigger = if (active.id in restoredVaultIds) {
                         "loadVaults:restoredUnlock"
@@ -636,8 +649,35 @@ class BitwardenViewModel(application: Application) : AndroidViewModel(applicatio
      * 页面进入时触发自动同步（节流+门控由 Orchestrator 负责）。
      */
     fun requestPageEnterAutoSync(vaultId: Long? = null) {
+        allVaultAutoSyncScheduler.cancelPending()
         val targetVaultId = vaultId ?: _activeVault.value?.id ?: return
         requestAutoSyncWithStartupGrace(targetVaultId, SyncTriggerReason.PAGE_ENTER)
+    }
+
+    /**
+     * ALL 视图持有的后台同步会话。
+     *
+     * 调用方必须在离开对应 ALL 视图时使用返回的 sessionId 调用
+     * [endAllViewAutoSync]。旧页面的 sessionId 无法取消新页面建立的会话。
+     */
+    fun beginAllViewAutoSync(): Long {
+        val elapsed = System.currentTimeMillis() - processStartMs
+        val coldStartRemaining = (COLD_START_AUTO_SYNC_GRACE_MS - elapsed).coerceAtLeast(0L)
+        val initialDelayMs = maxOf(1_200L, coldStartRemaining)
+        return allVaultAutoSyncScheduler.begin(initialDelayMs = initialDelayMs) {
+            if (!_isAutoSyncEnabled.value) {
+                emptyList()
+            } else {
+                BitwardenAutoSyncTargetPlanner.allViewTargets(
+                    unlockedVaultIds = awaitUnlockedVaultIds(),
+                    activeVaultId = _activeVault.value?.id
+                )
+            }
+        }
+    }
+
+    fun endAllViewAutoSync(sessionId: Long) {
+        allVaultAutoSyncScheduler.end(sessionId)
     }
 
     /**
@@ -646,8 +686,8 @@ class BitwardenViewModel(application: Application) : AndroidViewModel(applicatio
      * 不在 ViewModel init 中调用：非 Bitwarden 页面也会创建本 ViewModel，
      * init 自动同步会造成无关页面误触发。
      *
-     * 多账号时优先同步 preferred/active vault，其余已解锁 vault 错开排队，
-     * 再由 Orchestrator 串行执行被动同步，避免启动卡顿。
+     * 启动阶段只同步 preferred/active vault。全部账号的自动同步由明确的
+     * ALL 视图会话负责，避免普通页面启动时排队拉取所有账号。
      */
     fun requestStartupAutoSync(preferredVaultId: Long? = null) {
         if (!_isAutoSyncEnabled.value) {
@@ -657,53 +697,23 @@ class BitwardenViewModel(application: Application) : AndroidViewModel(applicatio
         viewModelScope.launch {
             // init loadVaults() is async; give never-lock restore a brief chance
             // to republish unlocked vaults before deciding there is nothing to sync.
-            var unlockedVaultIds = collectUnlockedVaultIds()
-            if (unlockedVaultIds.isEmpty()) {
-                delay(STARTUP_AUTO_SYNC_UNLOCK_WAIT_MS)
-                if (_vaults.value.isEmpty()) {
-                    runCatching {
-                        val vaultList = repository.getAllVaults()
-                        _vaults.value = vaultList
-                        replaceUnlockStates(vaultList)
-                    }
-                } else {
-                    replaceUnlockStates(_vaults.value)
-                }
-                unlockedVaultIds = collectUnlockedVaultIds()
-            }
+            val unlockedVaultIds = awaitUnlockedVaultIds()
             if (unlockedVaultIds.isEmpty()) {
                 Log.d(TAG, "Startup auto sync skipped: no unlocked vaults")
                 return@launch
             }
 
-            val preferred = preferredVaultId
-                ?.takeIf { it in unlockedVaultIds }
-                ?: _activeVault.value?.id?.takeIf { it in unlockedVaultIds }
-                ?: unlockedVaultIds.first()
+            val targetVaultId = BitwardenAutoSyncTargetPlanner.startupTarget(
+                unlockedVaultIds = unlockedVaultIds,
+                preferredVaultId = preferredVaultId,
+                activeVaultId = _activeVault.value?.id
+            ) ?: return@launch
 
-            val orderedVaultIds = buildList {
-                add(preferred)
-                unlockedVaultIds.forEach { vaultId ->
-                    if (vaultId != preferred) add(vaultId)
-                }
-            }
-
-            Log.d(
-                TAG,
-                "Startup auto sync scheduled for ${orderedVaultIds.size} unlocked vault(s), preferred=$preferred"
+            Log.d(TAG, "Startup auto sync scheduled for vault=$targetVaultId")
+            requestSyncWithStartupGrace(
+                vaultId = targetVaultId,
+                reason = SyncTriggerReason.APP_RESUME
             )
-            orderedVaultIds.forEachIndexed { index, vaultId ->
-                val reason = if (index == 0) {
-                    SyncTriggerReason.APP_RESUME
-                } else {
-                    SyncTriggerReason.PERIODIC
-                }
-                requestSyncWithStartupGrace(
-                    vaultId = vaultId,
-                    reason = reason,
-                    extraDelayMs = index * MULTI_VAULT_AUTO_SYNC_STAGGER_MS
-                )
-            }
         }
     }
 
@@ -1219,6 +1229,24 @@ class BitwardenViewModel(application: Application) : AndroidViewModel(applicatio
             .toList()
     }
 
+    private suspend fun awaitUnlockedVaultIds(): List<Long> {
+        var unlockedVaultIds = collectUnlockedVaultIds()
+        if (unlockedVaultIds.isNotEmpty()) return unlockedVaultIds
+
+        delay(STARTUP_AUTO_SYNC_UNLOCK_WAIT_MS)
+        runCatching {
+            if (_vaults.value.isEmpty()) {
+                refreshVaultListSnapshot()
+            } else {
+                replaceUnlockStates(_vaults.value)
+            }
+        }.onFailure { error ->
+            Log.w(TAG, "Failed to refresh unlocked vaults for auto sync", error)
+        }
+        unlockedVaultIds = collectUnlockedVaultIds()
+        return unlockedVaultIds
+    }
+
     private fun observeVaultSnapshots() {
         viewModelScope.launch {
             repository.getAllVaultsFlow().collect { vaultList ->
@@ -1404,26 +1432,6 @@ class BitwardenViewModel(application: Application) : AndroidViewModel(applicatio
         }
         Log.d(TAG, "Trigger auto sync: vault=${vault.id}, reason=$trigger")
         requestAutoSyncWithStartupGrace(vault.id, reason)
-    }
-
-    private fun requestAutoSyncForUnlockedVaults(vaults: List<BitwardenVault>, reason: SyncTriggerReason) {
-        val unlockedVaultIds = collectUnlockedVaultIds(vaults)
-        if (unlockedVaultIds.isEmpty()) return
-        val preferred = _activeVault.value?.id?.takeIf { it in unlockedVaultIds }
-            ?: unlockedVaultIds.first()
-        val orderedVaultIds = buildList {
-            add(preferred)
-            unlockedVaultIds.forEach { vaultId ->
-                if (vaultId != preferred) add(vaultId)
-            }
-        }
-        orderedVaultIds.forEachIndexed { index, vaultId ->
-            requestSyncWithStartupGrace(
-                vaultId = vaultId,
-                reason = reason,
-                extraDelayMs = index * MULTI_VAULT_AUTO_SYNC_STAGGER_MS
-            )
-        }
     }
 
     private fun requestAutoSyncWithStartupGrace(vaultId: Long, reason: SyncTriggerReason) {

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/bitwarden/viewmodel/BitwardenViewModel.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/bitwarden/viewmodel/BitwardenViewModel.kt
@@ -70,6 +70,8 @@ class BitwardenViewModel(application: Application) : AndroidViewModel(applicatio
     companion object {
         private const val TAG = "BitwardenViewModel"
         private const val COLD_START_AUTO_SYNC_GRACE_MS = 8_000L
+        private const val MULTI_VAULT_AUTO_SYNC_STAGGER_MS = 5_000L
+        private const val STARTUP_AUTO_SYNC_UNLOCK_WAIT_MS = 800L
         private const val SILENT_SYNC_UI_REFRESH_DELAY_MS = 1_500L
         private const val SILENT_SYNC_CACHE_WARM_DELAY_MS = 12_000L
     }
@@ -636,6 +638,73 @@ class BitwardenViewModel(application: Application) : AndroidViewModel(applicatio
     fun requestPageEnterAutoSync(vaultId: Long? = null) {
         val targetVaultId = vaultId ?: _activeVault.value?.id ?: return
         requestAutoSyncWithStartupGrace(targetVaultId, SyncTriggerReason.PAGE_ENTER)
+    }
+
+    /**
+     * App 启动/主界面认证通过后触发自动同步。
+     *
+     * 不在 ViewModel init 中调用：非 Bitwarden 页面也会创建本 ViewModel，
+     * init 自动同步会造成无关页面误触发。
+     *
+     * 多账号时优先同步 preferred/active vault，其余已解锁 vault 错开排队，
+     * 再由 Orchestrator 串行执行被动同步，避免启动卡顿。
+     */
+    fun requestStartupAutoSync(preferredVaultId: Long? = null) {
+        if (!_isAutoSyncEnabled.value) {
+            Log.d(TAG, "Startup auto sync skipped: auto sync disabled")
+            return
+        }
+        viewModelScope.launch {
+            // init loadVaults() is async; give never-lock restore a brief chance
+            // to republish unlocked vaults before deciding there is nothing to sync.
+            var unlockedVaultIds = collectUnlockedVaultIds()
+            if (unlockedVaultIds.isEmpty()) {
+                delay(STARTUP_AUTO_SYNC_UNLOCK_WAIT_MS)
+                if (_vaults.value.isEmpty()) {
+                    runCatching {
+                        val vaultList = repository.getAllVaults()
+                        _vaults.value = vaultList
+                        replaceUnlockStates(vaultList)
+                    }
+                } else {
+                    replaceUnlockStates(_vaults.value)
+                }
+                unlockedVaultIds = collectUnlockedVaultIds()
+            }
+            if (unlockedVaultIds.isEmpty()) {
+                Log.d(TAG, "Startup auto sync skipped: no unlocked vaults")
+                return@launch
+            }
+
+            val preferred = preferredVaultId
+                ?.takeIf { it in unlockedVaultIds }
+                ?: _activeVault.value?.id?.takeIf { it in unlockedVaultIds }
+                ?: unlockedVaultIds.first()
+
+            val orderedVaultIds = buildList {
+                add(preferred)
+                unlockedVaultIds.forEach { vaultId ->
+                    if (vaultId != preferred) add(vaultId)
+                }
+            }
+
+            Log.d(
+                TAG,
+                "Startup auto sync scheduled for ${orderedVaultIds.size} unlocked vault(s), preferred=$preferred"
+            )
+            orderedVaultIds.forEachIndexed { index, vaultId ->
+                val reason = if (index == 0) {
+                    SyncTriggerReason.APP_RESUME
+                } else {
+                    SyncTriggerReason.PERIODIC
+                }
+                requestSyncWithStartupGrace(
+                    vaultId = vaultId,
+                    reason = reason,
+                    extraDelayMs = index * MULTI_VAULT_AUTO_SYNC_STAGGER_MS
+                )
+            }
+        }
     }
 
     /**
@@ -1338,8 +1407,22 @@ class BitwardenViewModel(application: Application) : AndroidViewModel(applicatio
     }
 
     private fun requestAutoSyncForUnlockedVaults(vaults: List<BitwardenVault>, reason: SyncTriggerReason) {
-        collectUnlockedVaultIds(vaults).forEach { vaultId ->
-            requestSyncWithStartupGrace(vaultId, reason)
+        val unlockedVaultIds = collectUnlockedVaultIds(vaults)
+        if (unlockedVaultIds.isEmpty()) return
+        val preferred = _activeVault.value?.id?.takeIf { it in unlockedVaultIds }
+            ?: unlockedVaultIds.first()
+        val orderedVaultIds = buildList {
+            add(preferred)
+            unlockedVaultIds.forEach { vaultId ->
+                if (vaultId != preferred) add(vaultId)
+            }
+        }
+        orderedVaultIds.forEachIndexed { index, vaultId ->
+            requestSyncWithStartupGrace(
+                vaultId = vaultId,
+                reason = reason,
+                extraDelayMs = index * MULTI_VAULT_AUTO_SYNC_STAGGER_MS
+            )
         }
     }
 
@@ -1350,22 +1433,24 @@ class BitwardenViewModel(application: Application) : AndroidViewModel(applicatio
     private fun requestSyncWithStartupGrace(
         vaultId: Long,
         reason: SyncTriggerReason,
-        force: Boolean = false
+        force: Boolean = false,
+        extraDelayMs: Long = 0L
     ) {
         if (force || reason == SyncTriggerReason.MANUAL) {
             syncOrchestrator.requestSync(vaultId, reason, force = true)
             return
         }
         val elapsed = System.currentTimeMillis() - processStartMs
-        val remaining = COLD_START_AUTO_SYNC_GRACE_MS - elapsed
-        if (remaining <= 0L) {
+        val coldStartRemaining = (COLD_START_AUTO_SYNC_GRACE_MS - elapsed).coerceAtLeast(0L)
+        val delayMs = coldStartRemaining + extraDelayMs.coerceAtLeast(0L)
+        if (delayMs <= 0L) {
             syncOrchestrator.requestSync(vaultId, reason, force = force)
             return
         }
         syncOrchestrator.requestSyncWithDelay(
             vaultId = vaultId,
             reason = reason,
-            delayMs = remaining,
+            delayMs = delayMs,
             force = force
         )
     }
@@ -1612,8 +1697,10 @@ class BitwardenViewModel(application: Application) : AndroidViewModel(applicatio
         return repository.syncViaCoordinator(
             vaultId = vaultId,
             requestIdPrefix = "bw-vm-vault",
-            trigger = if (silent) SyncTrigger.PAGE_VISIBLE else SyncTrigger.MANUAL,
-            priority = if (silent) SyncPriority.PAGE_VISIBLE else SyncPriority.MANUAL,
+            // Silent/auto sync stays background-priority so multi-vault startup
+            // does not compete with interactive UI work at PAGE_VISIBLE rank.
+            trigger = if (silent) SyncTrigger.APP_START else SyncTrigger.MANUAL,
+            priority = if (silent) SyncPriority.BACKGROUND else SyncPriority.MANUAL,
             mode = if (silent) SyncMode.SILENT else SyncMode.FOREGROUND,
             networkPolicy = if (_isSyncOnWifiOnly.value) {
                 SyncNetworkPolicy.WIFI_ONLY

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/ui/password/PasswordListContent.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/ui/password/PasswordListContent.kt
@@ -127,6 +127,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import takagi.ru.monica.R
 import takagi.ru.monica.bitwarden.sync.isUserVisibleSyncInProgress
+import takagi.ru.monica.bitwarden.ui.BitwardenAutoSyncEffect
 import takagi.ru.monica.data.AppSettings
 import takagi.ru.monica.data.BottomNavContentTab
 import takagi.ru.monica.data.CategorySelectionUiMode
@@ -524,11 +525,11 @@ fun PasswordListContent(
     }
     val bitwardenViewModel: takagi.ru.monica.bitwarden.viewmodel.BitwardenViewModel = viewModel()
     val bitwardenSyncStatusByVault by bitwardenViewModel.syncStatusByVault.collectAsState()
-    LaunchedEffect(selectedBitwardenVaultId) {
-        val vaultId = selectedBitwardenVaultId ?: return@LaunchedEffect
-        delay(1_200L)
-        bitwardenViewModel.requestPageEnterAutoSync(vaultId)
-    }
+    BitwardenAutoSyncEffect(
+        viewModel = bitwardenViewModel,
+        selectedVaultId = selectedBitwardenVaultId,
+        isAllView = isAllView
+    )
     val selectedBitwardenFoldersFlow = remember(selectedBitwardenVaultId, viewModel) {
         selectedBitwardenVaultId?.let(viewModel::getBitwardenFolders)
             ?: kotlinx.coroutines.flow.flowOf(emptyList())

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/ui/password/PasswordListContent.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/ui/password/PasswordListContent.kt
@@ -524,6 +524,11 @@ fun PasswordListContent(
     }
     val bitwardenViewModel: takagi.ru.monica.bitwarden.viewmodel.BitwardenViewModel = viewModel()
     val bitwardenSyncStatusByVault by bitwardenViewModel.syncStatusByVault.collectAsState()
+    LaunchedEffect(selectedBitwardenVaultId) {
+        val vaultId = selectedBitwardenVaultId ?: return@LaunchedEffect
+        delay(1_200L)
+        bitwardenViewModel.requestPageEnterAutoSync(vaultId)
+    }
     val selectedBitwardenFoldersFlow = remember(selectedBitwardenVaultId, viewModel) {
         selectedBitwardenVaultId?.let(viewModel::getBitwardenFolders)
             ?: kotlinx.coroutines.flow.flowOf(emptyList())

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/ui/screens/CardWalletScreen.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/ui/screens/CardWalletScreen.kt
@@ -88,6 +88,7 @@ import takagi.ru.monica.bitwarden.sync.isUserVisibleSyncInProgress
 import takagi.ru.monica.bitwarden.repository.BitwardenRepository
 import takagi.ru.monica.bitwarden.sync.VaultSyncStatus
 import takagi.ru.monica.bitwarden.sync.syncForUserVisibleRequest
+import takagi.ru.monica.bitwarden.ui.BitwardenAutoSyncEffect
 import takagi.ru.monica.data.AppSettings
 import takagi.ru.monica.data.Category
 import takagi.ru.monica.data.ItemType
@@ -342,13 +343,15 @@ fun CardWalletScreen(
         )
     }
 
-    LaunchedEffect(selectedBitwardenVaultId, bitwardenViewModel) {
+    LaunchedEffect(selectedBitwardenVaultId) {
         onBitwardenScopeChanged(selectedBitwardenVaultId)
-        selectedBitwardenVaultId?.let { vaultId ->
-            delay(1_200L)
-            bitwardenViewModel?.requestPageEnterAutoSync(vaultId)
-        }
     }
+    BitwardenAutoSyncEffect(
+        viewModel = bitwardenViewModel,
+        selectedVaultId = selectedBitwardenVaultId,
+        isAllView = selectedCategoryFilter is UnifiedCategoryFilterSelection.All,
+        enabled = hasRestoredCategoryFilter
+    )
     DisposableEffect(Unit) {
         onDispose {
             onBitwardenScopeChanged(null)

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/ui/screens/NoteListScreen.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/ui/screens/NoteListScreen.kt
@@ -79,6 +79,7 @@ import takagi.ru.monica.data.isLocalOnlyItem
 import takagi.ru.monica.data.resolveOwnership
 import takagi.ru.monica.bitwarden.sync.isUserVisibleSyncInProgress
 import takagi.ru.monica.bitwarden.repository.BitwardenRepository
+import takagi.ru.monica.bitwarden.ui.BitwardenAutoSyncEffect
 import takagi.ru.monica.data.KeePassStorageLocation
 import takagi.ru.monica.data.bitwarden.BitwardenVault
 import takagi.ru.monica.repository.KeePassCompatibilityBridge
@@ -332,6 +333,12 @@ fun NoteListScreen(
     }
     val bitwardenViewModel: takagi.ru.monica.bitwarden.viewmodel.BitwardenViewModel = viewModel()
     val bitwardenSyncStatusByVault by bitwardenViewModel.syncStatusByVault.collectAsState()
+    BitwardenAutoSyncEffect(
+        viewModel = bitwardenViewModel,
+        selectedVaultId = selectedBitwardenVaultId,
+        isAllView = selectedCategoryFilter is NoteCategoryFilter.All,
+        enabled = hasRestoredCategoryFilter
+    )
     val isTopBarSyncing = selectedBitwardenVaultId?.let { vaultId ->
         bitwardenSyncStatusByVault[vaultId].isUserVisibleSyncInProgress()
     } == true

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/ui/screens/PasskeyListScreen.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/ui/screens/PasskeyListScreen.kt
@@ -63,6 +63,7 @@ import takagi.ru.monica.R
 import takagi.ru.monica.bitwarden.sync.isUserVisibleSyncInProgress
 import takagi.ru.monica.bitwarden.repository.BitwardenRepository
 import takagi.ru.monica.bitwarden.sync.syncForUserVisibleRequest
+import takagi.ru.monica.bitwarden.ui.BitwardenAutoSyncEffect
 import takagi.ru.monica.data.AppSettings
 import takagi.ru.monica.data.Category
 import takagi.ru.monica.data.isKeePassOwned
@@ -432,6 +433,12 @@ fun PasskeyListScreen(
     }
     val bitwardenViewModel: takagi.ru.monica.bitwarden.viewmodel.BitwardenViewModel = viewModel()
     val bitwardenSyncStatusByVault by bitwardenViewModel.syncStatusByVault.collectAsState()
+    BitwardenAutoSyncEffect(
+        viewModel = bitwardenViewModel,
+        selectedVaultId = selectedBitwardenVaultId,
+        isAllView = selectedCategoryFilter is UnifiedCategoryFilterSelection.All,
+        enabled = hasRestoredCategoryFilter
+    )
     val isTopBarSyncing = selectedBitwardenVaultId?.let { vaultId ->
         bitwardenSyncStatusByVault[vaultId].isUserVisibleSyncInProgress()
     } == true

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/ui/totp/TotpListContent.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/ui/totp/TotpListContent.kt
@@ -100,6 +100,7 @@ import androidx.fragment.app.FragmentActivity
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import takagi.ru.monica.R
 import takagi.ru.monica.bitwarden.sync.isUserVisibleSyncInProgress
@@ -350,6 +351,11 @@ fun TotpListContent(
     }
     val bitwardenViewModel: takagi.ru.monica.bitwarden.viewmodel.BitwardenViewModel = viewModel()
     val bitwardenSyncStatusByVault by bitwardenViewModel.syncStatusByVault.collectAsState()
+    LaunchedEffect(selectedBitwardenVaultId) {
+        val vaultId = selectedBitwardenVaultId ?: return@LaunchedEffect
+        delay(1_200L)
+        bitwardenViewModel.requestPageEnterAutoSync(vaultId)
+    }
     val isTopBarSyncing = selectedBitwardenVaultId?.let { vaultId ->
         bitwardenSyncStatusByVault[vaultId].isUserVisibleSyncInProgress()
     } == true

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/ui/totp/TotpListContent.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/ui/totp/TotpListContent.kt
@@ -104,6 +104,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import takagi.ru.monica.R
 import takagi.ru.monica.bitwarden.sync.isUserVisibleSyncInProgress
+import takagi.ru.monica.bitwarden.ui.BitwardenAutoSyncEffect
 import takagi.ru.monica.repository.KeePassCompatibilityBridge
 import takagi.ru.monica.repository.KeePassWorkspaceRepository
 import takagi.ru.monica.data.BottomNavContentTab
@@ -351,11 +352,11 @@ fun TotpListContent(
     }
     val bitwardenViewModel: takagi.ru.monica.bitwarden.viewmodel.BitwardenViewModel = viewModel()
     val bitwardenSyncStatusByVault by bitwardenViewModel.syncStatusByVault.collectAsState()
-    LaunchedEffect(selectedBitwardenVaultId) {
-        val vaultId = selectedBitwardenVaultId ?: return@LaunchedEffect
-        delay(1_200L)
-        bitwardenViewModel.requestPageEnterAutoSync(vaultId)
-    }
+    BitwardenAutoSyncEffect(
+        viewModel = bitwardenViewModel,
+        selectedVaultId = selectedBitwardenVaultId,
+        isAllView = currentFilter is takagi.ru.monica.viewmodel.TotpCategoryFilter.All
+    )
     val isTopBarSyncing = selectedBitwardenVaultId?.let { vaultId ->
         bitwardenSyncStatusByVault[vaultId].isUserVisibleSyncInProgress()
     } == true

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/ui/vaultv2/VaultV2Pane.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/ui/vaultv2/VaultV2Pane.kt
@@ -106,6 +106,7 @@ import kotlinx.serialization.json.Json
 import takagi.ru.monica.R
 import takagi.ru.monica.bitwarden.repository.BitwardenRepository
 import takagi.ru.monica.bitwarden.sync.isUserVisibleSyncInProgress
+import takagi.ru.monica.bitwarden.ui.BitwardenAutoSyncEffect
 import takagi.ru.monica.bitwarden.ui.UnlockVaultDialog
 import takagi.ru.monica.bitwarden.viewmodel.BitwardenViewModel
 import takagi.ru.monica.data.AppSettings
@@ -1536,11 +1537,14 @@ fun VaultV2Pane(
 			isTopActionsMenuExpanded = false
 			showBitwardenUnlockDialog = false
 			showClearBitwardenCacheDialog = false
-			return@LaunchedEffect
 		}
-		delay(1_200L)
-		bitwardenViewModel.requestPageEnterAutoSync(selectedBitwardenVaultId)
 	}
+	BitwardenAutoSyncEffect(
+		viewModel = bitwardenViewModel,
+		selectedVaultId = selectedBitwardenVaultId,
+		isAllView = storageSelection is UnifiedCategoryFilterSelection.All,
+		enabled = state.hasInitializedStorageFilter,
+	)
 	DisposableEffect(Unit) {
 		onDispose {
 			isTopActionsMenuExpanded = false

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/ui/vaultv2/VaultV2Pane.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/ui/vaultv2/VaultV2Pane.kt
@@ -1536,7 +1536,10 @@ fun VaultV2Pane(
 			isTopActionsMenuExpanded = false
 			showBitwardenUnlockDialog = false
 			showClearBitwardenCacheDialog = false
+			return@LaunchedEffect
 		}
+		delay(1_200L)
+		bitwardenViewModel.requestPageEnterAutoSync(selectedBitwardenVaultId)
 	}
 	DisposableEffect(Unit) {
 		onDispose {

--- a/Monica for Android/app/src/test/java/takagi/ru/monica/security/BiometricUnlockRegressionGuardTest.kt
+++ b/Monica for Android/app/src/test/java/takagi/ru/monica/security/BiometricUnlockRegressionGuardTest.kt
@@ -573,6 +573,9 @@ class BiometricUnlockRegressionGuardTest {
         val bitwardenViewModelSource = projectFile(
             "app/src/main/java/takagi/ru/monica/bitwarden/viewmodel/BitwardenViewModel.kt"
         ).readText()
+        val bitwardenAutoSyncEffectSource = projectFile(
+            "app/src/main/java/takagi/ru/monica/bitwarden/ui/BitwardenAutoSyncEffect.kt"
+        ).readText()
         val cardWalletScreenSource = projectFile(
             "app/src/main/java/takagi/ru/monica/ui/screens/CardWalletScreen.kt"
         ).readText()
@@ -668,24 +671,25 @@ class BiometricUnlockRegressionGuardTest {
         )
         assertTrue(
             "Page-visible auto sync triggers should wait for a short stable visibility window so fast bottom-tab switches cancel them.",
-                cardWalletScreenSource.contains("delay(1_200L)") &&
+                bitwardenAutoSyncEffectSource.contains("PAGE_ENTER_AUTO_SYNC_DELAY_MS = 1_200L") &&
+                bitwardenAutoSyncEffectSource.contains("targetViewModel.requestPageEnterAutoSync(targetVaultId)") &&
+                cardWalletScreenSource.contains("BitwardenAutoSyncEffect(") &&
                 cardWalletScreenSource.contains("SyncTaskRunner.request(") &&
-                cardWalletScreenSource.contains("bitwardenViewModel?.requestPageEnterAutoSync(vaultId)") &&
                 passkeyListScreenSource.contains("delay(1_200L)") &&
                 passkeyListScreenSource.contains("viewModel.refreshKeePassPasskeys(trigger = \"PASSKEY_PAGE_ENTER\")") &&
+                passkeyListScreenSource.contains("BitwardenAutoSyncEffect(") &&
                 sendScreenSource.contains("delay(1_200L)") &&
                 sendScreenSource.contains("bitwardenViewModel.requestPageEnterAutoSync()") &&
-                passwordListContentSource.contains("delay(1_200L)") &&
-                passwordListContentSource.contains("bitwardenViewModel.requestPageEnterAutoSync(vaultId)") &&
-                vaultV2PaneSource.contains("delay(1_200L)") &&
-                vaultV2PaneSource.contains("bitwardenViewModel.requestPageEnterAutoSync(selectedBitwardenVaultId)") &&
-                totpListContentForSyncSource.contains("delay(1_200L)") &&
-                totpListContentForSyncSource.contains("bitwardenViewModel.requestPageEnterAutoSync(vaultId)")
+                passwordListContentSource.contains("BitwardenAutoSyncEffect(") &&
+                vaultV2PaneSource.contains("BitwardenAutoSyncEffect(") &&
+                totpListContentForSyncSource.contains("BitwardenAutoSyncEffect(")
         )
         assertTrue(
             "Multi-account passive Bitwarden auto sync must be serialized to avoid startup jank.",
             bitwardenOrchestratorSource.contains("passiveAutoSyncMutex") &&
                 bitwardenViewModelSource.contains("fun requestStartupAutoSync(") &&
+                bitwardenViewModelSource.contains("BitwardenAutoSyncTargetPlanner.startupTarget(") &&
+                bitwardenViewModelSource.contains("BitwardenAllVaultAutoSyncScheduler(") &&
                 bitwardenViewModelSource.contains("MULTI_VAULT_AUTO_SYNC_STAGGER_MS") &&
                 mainActivitySource.contains("bitwardenViewModel.requestStartupAutoSync()")
         )

--- a/Monica for Android/app/src/test/java/takagi/ru/monica/security/BiometricUnlockRegressionGuardTest.kt
+++ b/Monica for Android/app/src/test/java/takagi/ru/monica/security/BiometricUnlockRegressionGuardTest.kt
@@ -582,6 +582,15 @@ class BiometricUnlockRegressionGuardTest {
         val sendScreenSource = projectFile(
             "app/src/main/java/takagi/ru/monica/ui/screens/SendScreen.kt"
         ).readText()
+        val passwordListContentSource = projectFile(
+            "app/src/main/java/takagi/ru/monica/ui/password/PasswordListContent.kt"
+        ).readText()
+        val vaultV2PaneSource = projectFile(
+            "app/src/main/java/takagi/ru/monica/ui/vaultv2/VaultV2Pane.kt"
+        ).readText()
+        val totpListContentForSyncSource = projectFile(
+            "app/src/main/java/takagi/ru/monica/ui/totp/TotpListContent.kt"
+        ).readText()
         val securityManagerSource = projectFile(
             "app/src/main/java/takagi/ru/monica/security/SecurityManager.kt"
         ).readText()
@@ -665,8 +674,22 @@ class BiometricUnlockRegressionGuardTest {
                 passkeyListScreenSource.contains("delay(1_200L)") &&
                 passkeyListScreenSource.contains("viewModel.refreshKeePassPasskeys(trigger = \"PASSKEY_PAGE_ENTER\")") &&
                 sendScreenSource.contains("delay(1_200L)") &&
-                sendScreenSource.contains("bitwardenViewModel.requestPageEnterAutoSync()")
+                sendScreenSource.contains("bitwardenViewModel.requestPageEnterAutoSync()") &&
+                passwordListContentSource.contains("delay(1_200L)") &&
+                passwordListContentSource.contains("bitwardenViewModel.requestPageEnterAutoSync(vaultId)") &&
+                vaultV2PaneSource.contains("delay(1_200L)") &&
+                vaultV2PaneSource.contains("bitwardenViewModel.requestPageEnterAutoSync(selectedBitwardenVaultId)") &&
+                totpListContentForSyncSource.contains("delay(1_200L)") &&
+                totpListContentForSyncSource.contains("bitwardenViewModel.requestPageEnterAutoSync(vaultId)")
         )
+        assertTrue(
+            "Multi-account passive Bitwarden auto sync must be serialized to avoid startup jank.",
+            bitwardenOrchestratorSource.contains("passiveAutoSyncMutex") &&
+                bitwardenViewModelSource.contains("fun requestStartupAutoSync(") &&
+                bitwardenViewModelSource.contains("MULTI_VAULT_AUTO_SYNC_STAGGER_MS") &&
+                mainActivitySource.contains("bitwardenViewModel.requestStartupAutoSync()")
+        )
+
         assertTrue(
             "Routine SecurityManager access checks must stay out of logcat hot paths; warning diagnostics remain separate.",
             securityManagerSource.contains("private fun logRoutineDebug(message: String)") &&

--- a/Monica for Android/app/src/test/java/takagi/ru/monica/sync/BitwardenAllVaultAutoSyncSchedulerTest.kt
+++ b/Monica for Android/app/src/test/java/takagi/ru/monica/sync/BitwardenAllVaultAutoSyncSchedulerTest.kt
@@ -1,0 +1,135 @@
+package takagi.ru.monica.sync
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import takagi.ru.monica.bitwarden.sync.BitwardenAllVaultAutoSyncScheduler
+
+class BitwardenAllVaultAutoSyncSchedulerTest {
+
+    @Test
+    fun allViewBatchRequestsDistinctVaultsSequentially() = runBlocking {
+        val rootJob = Job()
+        val scope = CoroutineScope(coroutineContext + rootJob)
+        val requestedVaultIds = mutableListOf<Long>()
+        val releaseFirst = CompletableDeferred<Unit>()
+        val releaseSecond = CompletableDeferred<Unit>()
+        val scheduler = BitwardenAllVaultAutoSyncScheduler(
+            scope = scope,
+            delayBetweenVaultsMs = 1L,
+            requestSync = { vaultId ->
+                requestedVaultIds += vaultId
+                scope.launch {
+                    when (vaultId) {
+                        1L -> releaseFirst.await()
+                        2L -> releaseSecond.await()
+                    }
+                }
+            }
+        )
+
+        try {
+            scheduler.begin(
+                initialDelayMs = 0L,
+                vaultIdsProvider = { listOf(1L, 1L, 2L) }
+            )
+
+            awaitCondition { requestedVaultIds == listOf(1L) }
+            delay(25L)
+            assertEquals(listOf(1L), requestedVaultIds)
+
+            releaseFirst.complete(Unit)
+            awaitCondition { requestedVaultIds == listOf(1L, 2L) }
+            releaseSecond.complete(Unit)
+            Unit
+        } finally {
+            rootJob.cancel()
+        }
+    }
+
+    @Test
+    fun leavingAllViewStopsPendingVaultsWithoutCancellingRunningSync() = runBlocking {
+        val rootJob = Job()
+        val scope = CoroutineScope(coroutineContext + rootJob)
+        val requestedVaultIds = mutableListOf<Long>()
+        val releaseFirst = CompletableDeferred<Unit>()
+        var runningSyncJob: Job? = null
+        val scheduler = BitwardenAllVaultAutoSyncScheduler(
+            scope = scope,
+            delayBetweenVaultsMs = 1L,
+            requestSync = { vaultId ->
+                requestedVaultIds += vaultId
+                scope.launch {
+                    if (vaultId == 1L) releaseFirst.await()
+                }.also { runningSyncJob = it }
+            }
+        )
+
+        try {
+            val sessionId = scheduler.begin(
+                initialDelayMs = 0L,
+                vaultIdsProvider = { listOf(1L, 2L) }
+            )
+            awaitCondition { requestedVaultIds == listOf(1L) }
+
+            scheduler.end(sessionId)
+            delay(25L)
+
+            assertEquals(listOf(1L), requestedVaultIds)
+            assertFalse(runningSyncJob?.isCancelled == true)
+
+            releaseFirst.complete(Unit)
+            delay(25L)
+            assertEquals(listOf(1L), requestedVaultIds)
+        } finally {
+            rootJob.cancel()
+        }
+    }
+
+    @Test
+    fun stalePageSessionCannotCancelNewAllViewBatch() = runBlocking {
+        val rootJob = Job()
+        val scope = CoroutineScope(coroutineContext + rootJob)
+        val requestedVaultIds = mutableListOf<Long>()
+        val scheduler = BitwardenAllVaultAutoSyncScheduler(
+            scope = scope,
+            delayBetweenVaultsMs = 0L,
+            requestSync = { vaultId ->
+                requestedVaultIds += vaultId
+                scope.launch { }
+            }
+        )
+
+        try {
+            val staleSessionId = scheduler.begin(
+                initialDelayMs = 1_000L,
+                vaultIdsProvider = { listOf(1L) }
+            )
+            scheduler.begin(
+                initialDelayMs = 1L,
+                vaultIdsProvider = { listOf(2L) }
+            )
+
+            scheduler.end(staleSessionId)
+            awaitCondition { requestedVaultIds == listOf(2L) }
+        } finally {
+            rootJob.cancel()
+        }
+    }
+
+    private suspend fun awaitCondition(condition: () -> Boolean) {
+        withTimeout(1_000L) {
+            while (!condition()) {
+                yield()
+            }
+        }
+    }
+}

--- a/Monica for Android/app/src/test/java/takagi/ru/monica/sync/BitwardenAutoSyncScopeGuardTest.kt
+++ b/Monica for Android/app/src/test/java/takagi/ru/monica/sync/BitwardenAutoSyncScopeGuardTest.kt
@@ -1,0 +1,92 @@
+package takagi.ru.monica.sync
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BitwardenAutoSyncScopeGuardTest {
+
+    @Test
+    fun startupAutoSyncTargetsOnePreferredOrActiveVault() {
+        val source = projectFile(
+            "src/main/java/takagi/ru/monica/bitwarden/viewmodel/BitwardenViewModel.kt"
+        ).readText()
+        val body = source
+            .substringAfter("fun requestStartupAutoSync(")
+            .substringBefore("fun requestLocalMutationSync(")
+
+        assertTrue(body.contains("BitwardenAutoSyncTargetPlanner.startupTarget("))
+        assertTrue(body.contains("SyncTriggerReason.APP_RESUME"))
+        assertFalse(body.contains("forEachIndexed"))
+        assertFalse(body.contains("SyncTriggerReason.PERIODIC"))
+    }
+
+    @Test
+    fun selectedVaultEntryCancelsPendingAllViewBatchBeforeSync() {
+        val source = projectFile(
+            "src/main/java/takagi/ru/monica/bitwarden/viewmodel/BitwardenViewModel.kt"
+        ).readText()
+        val body = source
+            .substringAfter("fun requestPageEnterAutoSync(")
+            .substringBefore("fun beginAllViewAutoSync(")
+
+        assertTrue(body.contains("allVaultAutoSyncScheduler.cancelPending()"))
+        assertTrue(body.indexOf("allVaultAutoSyncScheduler.cancelPending()") < body.indexOf("requestAutoSyncWithStartupGrace"))
+    }
+
+    @Test
+    fun allViewBatchUsesBackgroundPeriodicReason() {
+        val source = projectFile(
+            "src/main/java/takagi/ru/monica/bitwarden/viewmodel/BitwardenViewModel.kt"
+        ).readText()
+        val schedulerBody = source
+            .substringAfter("private val allVaultAutoSyncScheduler")
+            .substringBefore("val syncStatusByVault")
+
+        assertTrue(schedulerBody.contains("SyncTriggerReason.PERIODIC"))
+        assertFalse(schedulerBody.contains("SyncTriggerReason.MANUAL"))
+    }
+
+    @Test
+    fun allCapableListPagesUseExplicitAllViewScopeInsteadOfNullableVaultInference() {
+        val expectedSources = mapOf(
+            "src/main/java/takagi/ru/monica/ui/password/PasswordListContent.kt" to "isAllView = isAllView",
+            "src/main/java/takagi/ru/monica/ui/totp/TotpListContent.kt" to "TotpCategoryFilter.All",
+            "src/main/java/takagi/ru/monica/ui/screens/CardWalletScreen.kt" to "UnifiedCategoryFilterSelection.All",
+            "src/main/java/takagi/ru/monica/ui/screens/NoteListScreen.kt" to "NoteCategoryFilter.All",
+            "src/main/java/takagi/ru/monica/ui/screens/PasskeyListScreen.kt" to "UnifiedCategoryFilterSelection.All",
+            "src/main/java/takagi/ru/monica/ui/vaultv2/VaultV2Pane.kt" to "UnifiedCategoryFilterSelection.All"
+        )
+
+        expectedSources.forEach { (path, allMarker) ->
+            val source = projectFile(path).readText()
+            assertTrue("$path must install the shared Bitwarden auto-sync scope effect.", source.contains("BitwardenAutoSyncEffect("))
+            assertTrue("$path must identify ALL explicitly.", source.contains(allMarker))
+        }
+    }
+
+    @Test
+    fun localMutationKeepsTheOwningVaultId() {
+        val source = projectFile(
+            "src/main/java/takagi/ru/monica/bitwarden/viewmodel/BitwardenViewModel.kt"
+        ).readText()
+        val bridgeBody = source.substringAfter("BitwardenMutationSyncBridge.register(this)")
+            .substringBefore("observeVaultSnapshots()")
+        val mutationBody = source.substringAfter("fun requestLocalMutationSync(")
+            .substringBefore("fun requestManualSync(")
+
+        assertTrue(bridgeBody.contains("vaultId = vaultId"))
+        assertTrue(bridgeBody.contains("SyncTriggerReason.LOCAL_MUTATION"))
+        assertTrue(mutationBody.contains("val targetVaultId = vaultId"))
+        assertTrue(mutationBody.contains("vaultId = targetVaultId"))
+    }
+
+    private fun projectFile(relativePath: String): File {
+        val fromModule = File(relativePath)
+        if (fromModule.exists()) return fromModule
+        val fromAndroidRoot = File("app", relativePath)
+        if (fromAndroidRoot.exists()) return fromAndroidRoot
+        return File("Monica for Android/app", relativePath)
+    }
+}

--- a/Monica for Android/app/src/test/java/takagi/ru/monica/sync/BitwardenAutoSyncTargetPlannerTest.kt
+++ b/Monica for Android/app/src/test/java/takagi/ru/monica/sync/BitwardenAutoSyncTargetPlannerTest.kt
@@ -1,0 +1,59 @@
+package takagi.ru.monica.sync
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import takagi.ru.monica.bitwarden.sync.BitwardenAutoSyncTargetPlanner
+
+class BitwardenAutoSyncTargetPlannerTest {
+
+    @Test
+    fun startupSelectsOnlyPreferredUnlockedVault() {
+        assertEquals(
+            7L,
+            BitwardenAutoSyncTargetPlanner.startupTarget(
+                unlockedVaultIds = listOf(3L, 7L, 9L),
+                preferredVaultId = 7L,
+                activeVaultId = 3L
+            )
+        )
+    }
+
+    @Test
+    fun startupFallsBackToActiveThenFirstUnlockedVault() {
+        assertEquals(
+            3L,
+            BitwardenAutoSyncTargetPlanner.startupTarget(
+                unlockedVaultIds = listOf(3L, 7L),
+                preferredVaultId = 99L,
+                activeVaultId = 3L
+            )
+        )
+        assertEquals(
+            7L,
+            BitwardenAutoSyncTargetPlanner.startupTarget(
+                unlockedVaultIds = listOf(7L, 9L),
+                preferredVaultId = 99L,
+                activeVaultId = 88L
+            )
+        )
+        assertNull(
+            BitwardenAutoSyncTargetPlanner.startupTarget(
+                unlockedVaultIds = emptyList(),
+                preferredVaultId = 7L,
+                activeVaultId = 3L
+            )
+        )
+    }
+
+    @Test
+    fun allViewOrdersActiveVaultFirstAndRemovesDuplicates() {
+        assertEquals(
+            listOf(2L, 3L, 1L),
+            BitwardenAutoSyncTargetPlanner.allViewTargets(
+                unlockedVaultIds = listOf(3L, 2L, 3L, 1L),
+                activeVaultId = 2L
+            )
+        )
+    }
+}

--- a/Monica for Android/app/src/test/java/takagi/ru/monica/sync/BitwardenSyncOrchestratorTest.kt
+++ b/Monica for Android/app/src/test/java/takagi/ru/monica/sync/BitwardenSyncOrchestratorTest.kt
@@ -134,4 +134,68 @@ class BitwardenSyncOrchestratorTest {
             job.cancel()
         }
     }
+
+    @Test
+    fun passiveAutoSyncRunsSeriallyAcrossVaults() = runBlocking {
+        val job = Job()
+        val running = AtomicInteger(0)
+        val maxConcurrent = AtomicInteger(0)
+        val startedSecond = CompletableDeferred<Unit>()
+        val releaseFirst = CompletableDeferred<Unit>()
+        val finished = AtomicInteger(0)
+
+        val orchestrator = BitwardenSyncOrchestrator(
+            scope = CoroutineScope(coroutineContext + job),
+            config = SyncManagerConfig(
+                pageEnterThrottleMs = 1L,
+                appResumeThrottleMs = 1L
+            ),
+            isAutoSyncEnabled = { true },
+            checkNetwork = { NetworkGateResult.ALLOWED },
+            isVaultUnlocked = { true },
+            executeSync = { vaultId, _ ->
+                val current = running.incrementAndGet()
+                maxConcurrent.accumulateAndGet(current) { a, b -> maxOf(a, b) }
+                if (vaultId == 1L) {
+                    releaseFirst.await()
+                } else {
+                    startedSecond.complete(Unit)
+                }
+                running.decrementAndGet()
+                finished.incrementAndGet()
+                SyncExecutionOutcome.Success(
+                    appliedChangeCount = 0,
+                    availableOfflineCount = 0,
+                    conflictCount = 0,
+                    uploadFailedCount = 0,
+                    skippedDueToLocalDirtyCount = 0
+                )
+            }
+        )
+
+        try {
+            orchestrator.requestSync(vaultId = 1L, reason = SyncTriggerReason.APP_RESUME)
+            delay(30L)
+            orchestrator.requestSync(vaultId = 2L, reason = SyncTriggerReason.PERIODIC)
+            delay(30L)
+            assertEquals(
+                "Second vault passive auto-sync must wait while another vault is syncing.",
+                false,
+                startedSecond.isCompleted
+            )
+            releaseFirst.complete(Unit)
+            withTimeout(1_000L) { startedSecond.await() }
+            repeat(10) { yield() }
+            delay(50L)
+
+            assertEquals(
+                "Passive auto-sync across multiple Bitwarden vaults must never run in parallel.",
+                1,
+                maxConcurrent.get()
+            )
+            assertEquals(2, finished.get())
+        } finally {
+            job.cancel()
+        }
+    }
 }

--- a/Monica for Android/app/src/test/java/takagi/ru/monica/ui/cardwallet/CardWalletSyncScopeTest.kt
+++ b/Monica for Android/app/src/test/java/takagi/ru/monica/ui/cardwallet/CardWalletSyncScopeTest.kt
@@ -129,8 +129,10 @@ class CardWalletSyncScopeTest {
             viewModelSource.contains("fun requestStartupAutoSync(")
         )
         assertTrue(
-            "Multi-vault startup auto sync must stagger extra accounts.",
-            viewModelSource.contains("MULTI_VAULT_AUTO_SYNC_STAGGER_MS")
+            "Startup auto sync must choose one preferred or active vault; multi-vault work belongs to ALL-view sessions.",
+            viewModelSource.contains("BitwardenAutoSyncTargetPlanner.startupTarget(") &&
+                viewModelSource.contains("BitwardenAllVaultAutoSyncScheduler(") &&
+                viewModelSource.contains("fun beginAllViewAutoSync()")
         )
     }
 

--- a/Monica for Android/app/src/test/java/takagi/ru/monica/ui/cardwallet/CardWalletSyncScopeTest.kt
+++ b/Monica for Android/app/src/test/java/takagi/ru/monica/ui/cardwallet/CardWalletSyncScopeTest.kt
@@ -124,6 +124,28 @@ class CardWalletSyncScopeTest {
             "Creating BitwardenViewModel from non-Bitwarden pages must not enqueue Bitwarden auto sync.",
             initBody.contains("triggerStartupAutoSync = true")
         )
+        assertTrue(
+            "Startup auto sync must be an explicit API so MainActivity can trigger it after auth.",
+            viewModelSource.contains("fun requestStartupAutoSync(")
+        )
+        assertTrue(
+            "Multi-vault startup auto sync must stagger extra accounts.",
+            viewModelSource.contains("MULTI_VAULT_AUTO_SYNC_STAGGER_MS")
+        )
+    }
+
+    @Test
+    fun mainActivityTriggersStartupAutoSyncAfterAuthentication() {
+        val mainActivitySource = projectFile("src/main/java/takagi/ru/monica/MainActivity.kt").readText()
+        assertTrue(
+            "Authenticated main entry must request Bitwarden startup auto sync.",
+            mainActivitySource.contains("bitwardenViewModel.requestStartupAutoSync()")
+        )
+        assertTrue(
+            "Startup auto sync should wait for a short stable authenticated window.",
+            mainActivitySource.contains("delay(1_200L)") &&
+                mainActivitySource.contains("requestStartupAutoSync()")
+        )
     }
 
     private fun projectFile(relativePath: String): File {


### PR DESCRIPTION
# 背景 / 问题

配置多个 Bitwarden 账号（vault）时，App 启动或进入密码/TOTP/保险库页面会同时触发多个 vault 的自动同步。多个同步任务并发抢占网络与 CPU，且静默同步此前以 `PAGE_VISIBLE` 优先级运行，与交互式 UI 任务同级竞争，导致明显卡顿。

此外，自动同步依赖 ViewModel `init` 时机，非 Bitwarden 页面创建 ViewModel 也会误触发。

---

# 主要改动

## 同步编排（`BitwardenSyncOrchestrator`）

- **新增 `passiveAutoSyncMutex` 全局锁**  
  被动自动同步（`PAGE_ENTER` / `APP_RESUME` / `PERIODIC`）跨 vault **串行执行**，同一时刻只有一个 vault 在做被动同步；  
  手动同步、数据变更同步与强制重试**不经过该锁**，保持即时响应。

- **`PERIODIC` 纳入被动同步语义**  
  并复用 `APP_RESUME` 的静默窗口节流。

---

## 触发策略（`BitwardenViewModel`）

- **新增 `requestStartupAutoSync()` 显式启动同步入口**  
  替代隐式的 `init` 触发，避免无关页面误触发。内部处理：
  - 等待解锁状态恢复（800ms）
  - 必要时兜底加载 vault 列表
  - 优先同步 preferred/active vault（`APP_RESUME`）。

- **`requestAutoSyncForUnlockedVaults` 同样按 preferred 优先**。

- **`requestSyncWithStartupGrace` 支持 `extraDelayMs`**  
  错峰延迟与冷启动宽限期（8 秒）叠加计算。

- **静默同步优先级从 `PAGE_VISIBLE` 降为 `BACKGROUND`**  
  触发器相应改为 `APP_START`，不再与交互式 UI 任务争抢。